### PR TITLE
Migration firmware ESP32 vers PlatformIO (profil esp32dev)

### DIFF
--- a/hardware/firmware/esp32/README.md
+++ b/hardware/firmware/esp32/README.md
@@ -1,7 +1,52 @@
 # Firmware ESP32 (MIT)
 
-Mettre ici :
-- code ESP32
-- instructions (Arduino IDE / PlatformIO si utilisé)
-- mapping GPIO
-- comportement (Wi-Fi/BLE si utilisé)
+## Version PlatformIO (ESP32 DevKit)
+
+Ce dossier contient maintenant un projet **PlatformIO** prêt à compiler, sans code préalable requis.
+
+- Configuration : `platformio.ini`
+- Code : `src/main.cpp`
+
+## Fonctionnalités
+
+- LED RGB en clignotement aléatoire.
+- Si le micro capte un **LA (~440 Hz)**, la LED passe en **vert**.
+- Génération d'une sinusoïde **~440 Hz** sur le DAC interne (`GPIO25`).
+- Lecture d'un MP3 (`/track001.mp3`) depuis la carte SD (boucle automatique).
+
+## GPIO utilisés (profil ESP32 DevKit)
+
+- LED RGB externe :
+  - `GPIO16` (R)
+  - `GPIO17` (G)
+  - `GPIO4` (B)
+- Micro analogique : `GPIO34`
+- DAC sinus : `GPIO25`
+- SD (VSPI standard ESP32) :
+  - `CS GPIO5`
+  - `SCK GPIO18`
+  - `MISO GPIO19`
+  - `MOSI GPIO23`
+- I2S MP3 (DAC/ampli I2S externe) :
+  - `BCLK GPIO26`
+  - `LRC GPIO27`
+  - `DOUT GPIO22`
+
+## Dépendance
+
+- `earlephilhower/ESP8266Audio`
+
+## Utilisation rapide
+
+1. Mettre `track001.mp3` à la racine de la carte SD.
+2. Ouvrir ce dossier avec PlatformIO.
+3. Compiler et flasher :
+   - `pio run`
+   - `pio run -t upload`
+4. Ouvrir le moniteur série :
+   - `pio device monitor`
+
+## Réglages
+
+- Le seuil de détection du LA se règle via `DETECT_RATIO_THRESHOLD` dans `src/main.cpp`.
+- Si votre câblage diffère, modifier les constantes GPIO en tête de `src/main.cpp`.

--- a/hardware/firmware/esp32/platformio.ini
+++ b/hardware/firmware/esp32/platformio.ini
@@ -1,0 +1,9 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+  earlephilhower/ESP8266Audio@^1.9.7
+build_flags =
+  -DCORE_DEBUG_LEVEL=1

--- a/hardware/firmware/esp32/src/main.cpp
+++ b/hardware/firmware/esp32/src/main.cpp
@@ -1,0 +1,250 @@
+#include <Arduino.h>
+#include <SD.h>
+#include <SPI.h>
+#include <AudioFileSourceSD.h>
+#include <AudioGeneratorMP3.h>
+#include <AudioOutputI2S.h>
+
+// -------------------- ESP32 DevKit GPIO --------------------
+// RGB LED externe (3 sorties digitales)
+static constexpr uint8_t PIN_LED_R = 16;
+static constexpr uint8_t PIN_LED_G = 17;
+static constexpr uint8_t PIN_LED_B = 4;
+
+// Micro analogique
+static constexpr uint8_t PIN_MIC = 34;
+
+// DAC interne pour sinus
+static constexpr uint8_t PIN_DAC_SINE = 25;
+
+// Carte SD (bus VSPI standard ESP32 DevKit)
+static constexpr uint8_t PIN_SD_CS = 5;
+static constexpr uint8_t PIN_SD_SCK = 18;
+static constexpr uint8_t PIN_SD_MISO = 19;
+static constexpr uint8_t PIN_SD_MOSI = 23;
+
+// I2S sortie MP3 (vers DAC/ampli I2S externe type MAX98357A)
+static constexpr uint8_t PIN_I2S_BCLK = 26;
+static constexpr uint8_t PIN_I2S_LRC = 27;
+static constexpr uint8_t PIN_I2S_DOUT = 22;
+
+static constexpr char MP3_PATH[] = "/track001.mp3";
+
+// -------------------- MP3 --------------------
+AudioGeneratorMP3* mp3 = nullptr;
+AudioFileSourceSD* mp3File = nullptr;
+AudioOutputI2S* i2sOut = nullptr;
+
+// -------------------- DAC sinus 440 Hz --------------------
+static constexpr float SINE_FREQ_HZ = 440.0f;
+static constexpr uint16_t DAC_SAMPLE_RATE = 22050;
+static constexpr uint16_t SINE_TABLE_SIZE = 128;
+uint8_t sineTable[SINE_TABLE_SIZE];
+uint32_t lastDacMicros = 0;
+uint32_t dacPeriodUs = 1000000UL / DAC_SAMPLE_RATE;
+
+// -------------------- Détection LA (Goertzel) --------------------
+static constexpr float DETECT_FS = 4000.0f;
+static constexpr uint16_t DETECT_N = 128;
+static constexpr float DETECT_TARGET_HZ = 440.0f;
+static constexpr float DETECT_RATIO_THRESHOLD = 1.8f;
+static constexpr uint16_t DETECT_EVERY_MS = 100;
+
+bool laDetected = false;
+uint32_t lastDetectMs = 0;
+
+// -------------------- LED random --------------------
+uint32_t nextLedUpdateMs = 0;
+
+void setLed(bool r, bool g, bool b) {
+  digitalWrite(PIN_LED_R, r ? HIGH : LOW);
+  digitalWrite(PIN_LED_G, g ? HIGH : LOW);
+  digitalWrite(PIN_LED_B, b ? HIGH : LOW);
+}
+
+void updateLedRandom(uint32_t nowMs) {
+  if (nowMs < nextLedUpdateMs) {
+    return;
+  }
+
+  // Pas de vert seul pour garder la signification "LA détecté"
+  const uint8_t mode = random(0, 5);
+  switch (mode) {
+    case 0:
+      setLed(true, false, false);
+      break;  // rouge
+    case 1:
+      setLed(false, false, true);
+      break;  // bleu
+    case 2:
+      setLed(true, false, true);
+      break;  // violet
+    case 3:
+      setLed(true, true, false);
+      break;  // jaune
+    default:
+      setLed(false, false, false);
+      break;  // off
+  }
+
+  nextLedUpdateMs = nowMs + random(120, 500);
+}
+
+void buildSineTable() {
+  for (uint16_t i = 0; i < SINE_TABLE_SIZE; ++i) {
+    const float phase = 2.0f * PI * static_cast<float>(i) / static_cast<float>(SINE_TABLE_SIZE);
+    const float normalized = 0.5f + 0.5f * sinf(phase);
+    sineTable[i] = static_cast<uint8_t>(normalized * 255.0f);
+  }
+}
+
+void updateDacSine() {
+  const uint32_t nowUs = micros();
+  if ((nowUs - lastDacMicros) < dacPeriodUs) {
+    return;
+  }
+
+  lastDacMicros = nowUs;
+
+  static float phaseAcc = 0.0f;
+  const float step = (SINE_FREQ_HZ * static_cast<float>(SINE_TABLE_SIZE)) /
+                     static_cast<float>(DAC_SAMPLE_RATE);
+  phaseAcc += step;
+  if (phaseAcc >= SINE_TABLE_SIZE) {
+    phaseAcc -= SINE_TABLE_SIZE;
+  }
+
+  const uint8_t sample = sineTable[static_cast<uint16_t>(phaseAcc)];
+  dacWrite(PIN_DAC_SINE, sample);
+}
+
+float goertzelPower(const int16_t* x, uint16_t n, float fs, float targetHz) {
+  const float k = roundf((static_cast<float>(n) * targetHz) / fs);
+  const float omega = (2.0f * PI * k) / static_cast<float>(n);
+  const float coeff = 2.0f * cosf(omega);
+
+  float s0 = 0.0f;
+  float s1 = 0.0f;
+  float s2 = 0.0f;
+
+  for (uint16_t i = 0; i < n; ++i) {
+    s0 = x[i] + coeff * s1 - s2;
+    s2 = s1;
+    s1 = s0;
+  }
+
+  return (s1 * s1) + (s2 * s2) - (coeff * s1 * s2);
+}
+
+bool detectLA440() {
+  static int16_t samples[DETECT_N];
+
+  int32_t meanAccum = 0;
+  for (uint16_t i = 0; i < DETECT_N; ++i) {
+    const int16_t v = static_cast<int16_t>(analogRead(PIN_MIC));
+    samples[i] = v;
+    meanAccum += v;
+    delayMicroseconds(static_cast<uint32_t>(1000000.0f / DETECT_FS));
+  }
+
+  const float mean = static_cast<float>(meanAccum) / static_cast<float>(DETECT_N);
+  float totalEnergy = 0.0f;
+
+  for (uint16_t i = 0; i < DETECT_N; ++i) {
+    const int16_t centered = static_cast<int16_t>(samples[i] - mean);
+    samples[i] = centered;
+    totalEnergy += static_cast<float>(centered) * static_cast<float>(centered);
+  }
+
+  if (totalEnergy < 1.0f) {
+    return false;
+  }
+
+  const float targetEnergy = goertzelPower(samples, DETECT_N, DETECT_FS, DETECT_TARGET_HZ);
+  const float ratio = targetEnergy / (totalEnergy + 1.0f);
+  return ratio > DETECT_RATIO_THRESHOLD;
+}
+
+void startMp3() {
+  if (!SD.exists(MP3_PATH)) {
+    Serial.printf("[MP3] Fichier absent: %s\n", MP3_PATH);
+    return;
+  }
+
+  mp3File = new AudioFileSourceSD(MP3_PATH);
+  i2sOut = new AudioOutputI2S();
+  i2sOut->SetPinout(PIN_I2S_BCLK, PIN_I2S_LRC, PIN_I2S_DOUT);
+  i2sOut->SetGain(0.20f);
+
+  mp3 = new AudioGeneratorMP3();
+  mp3->begin(mp3File, i2sOut);
+  Serial.println("[MP3] Lecture en cours.");
+}
+
+void initSdAndMp3() {
+  SPI.begin(PIN_SD_SCK, PIN_SD_MISO, PIN_SD_MOSI, PIN_SD_CS);
+
+  if (!SD.begin(PIN_SD_CS)) {
+    Serial.println("[MP3] Carte SD non détectée.");
+    return;
+  }
+
+  startMp3();
+}
+
+void loopMp3() {
+  if (mp3 == nullptr) {
+    return;
+  }
+
+  if (mp3->isRunning()) {
+    mp3->loop();
+    return;
+  }
+
+  mp3->stop();
+  delete mp3;
+  delete mp3File;
+  mp3 = nullptr;
+  mp3File = nullptr;
+
+  startMp3();
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(200);
+
+  pinMode(PIN_LED_R, OUTPUT);
+  pinMode(PIN_LED_G, OUTPUT);
+  pinMode(PIN_LED_B, OUTPUT);
+  setLed(false, false, false);
+
+  analogReadResolution(12);
+  analogSetPinAttenuation(PIN_MIC, ADC_11db);
+
+  randomSeed(analogRead(PIN_MIC));
+
+  buildSineTable();
+  initSdAndMp3();
+
+  Serial.println("[BOOT] U-SON / ESP32 DevKit prêt.");
+}
+
+void loop() {
+  const uint32_t nowMs = millis();
+
+  updateDacSine();
+  loopMp3();
+
+  if ((nowMs - lastDetectMs) >= DETECT_EVERY_MS) {
+    lastDetectMs = nowMs;
+    laDetected = detectLA440();
+  }
+
+  if (laDetected) {
+    setLed(false, true, false);
+  } else {
+    updateLedRandom(nowMs);
+  }
+}

--- a/hardware/firmware/esp32/u_son_audio_dev_kit.ino
+++ b/hardware/firmware/esp32/u_son_audio_dev_kit.ino
@@ -1,0 +1,11 @@
+/*
+  Deprecated entrypoint.
+  Le projet est désormais maintenu en version PlatformIO:
+  - platformio.ini
+  - src/main.cpp
+
+  Ce fichier est conservé uniquement pour compatibilité historique.
+*/
+
+void setup() {}
+void loop() {}


### PR DESCRIPTION
### Motivation

- Remplacer l’ancien point d’entrée `.ino` par un projet PlatformIO structuré afin d’avoir un workflow de build/flash reproductible pour la carte ESP32 DevKit.
- Fournir un sketch maintenable avec un mapping GPIO explicite DevKit et réunir les fonctionnalités attendues (LED RGB, détection 440 Hz, sortie DAC sinusoïde, lecture MP3 depuis SD).

### Description

- Ajout de `hardware/firmware/esp32/platformio.ini` configuré pour `board = esp32dev` et la dépendance `earlephilhower/ESP8266Audio`.
- Ajout de `hardware/firmware/esp32/src/main.cpp` qui implémente la LED RGB aléatoire, la détection de LA (~440 Hz) via Goertzel, la génération d’une sinusoïde ~440 Hz sur le DAC (`GPIO25`) et la lecture MP3 en boucle depuis la SD via I2S avec `SetPinout(26,27,22)`.
- Mise à jour de `hardware/firmware/esp32/README.md` pour documenter le nouveau workflow PlatformIO, le mapping GPIO DevKit et les réglages (`DETECT_RATIO_THRESHOLD`).
- Remplacement de l’ancien `u_son_audio_dev_kit.ino` par un stub minimal pour compatibilité historique afin d’éviter la confusion sur le point d’entrée (maintien du code actif dans `src/main.cpp`).

### Testing

- Tentative d’inspection de l’environnement PlatformIO via `cd hardware/firmware/esp32 && pio --version` a échoué car `pio` n’est pas installé dans cet environnement (`command not found`), donc aucune compilation automatisée n’a été lancée.
- Aucune autre suite de tests automatisés (compilation ou unitaires) n’a été exécutée dans l’environnement CI local.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dc8f23fbc83318e21c8ac76a26eb6)