### PR TITLE
sync(codex): ajouter rollback Story V2 docs

### DIFF
--- a/hardware/firmware/esp32/README.md
+++ b/hardware/firmware/esp32/README.md
@@ -149,6 +149,8 @@ Notes:
 - `STORY_STATUS` expose un `stage` explicite: `WAIT_UNLOCK`, `WIN_PENDING`, `WAIT_ETAPE2`, `ETAPE2_DONE`.
 - Le moteur STORY V2 est protege par le flag `kStoryV2EnabledDefault` (default `false`).
 - Si le flag V2 est OFF, `STORY_V2_EVENT/STEP/SCENARIO/VALIDATE/HEALTH` repondent `OUT_OF_CONTEXT`.
+- Rollback runtime immediat: `STORY_V2_ENABLE OFF` (retour controleur legacy sans reflash).
+- Rollback release: conserver `kStoryV2EnabledDefault=false` puis recompiler/reflasher.
 - Les delais par defaut sont configures dans `src/config.h`:
   - `kStoryEtape2DelayMs` (production, defaut 15 min)
   - `kStoryEtape2TestDelayMs` (test rapide)

--- a/hardware/firmware/esp32/TESTING.md
+++ b/hardware/firmware/esp32/TESTING.md
@@ -177,6 +177,12 @@ Procedure rapide:
 14. Envoyer `STORY_V2_TRACE OFF`.
 15. Envoyer `STORY_TEST_OFF`.
 
+Rollback (si anomalie en live):
+
+1. Envoyer `STORY_V2_ENABLE OFF` pour revenir sur le controleur legacy sans reflash.
+2. Verifier `STORY_STATUS` et `STORY_V2_STATUS` (attendu: V2 desactive).
+3. Pour un rollback durable, remettre `kStoryV2EnabledDefault=false`, recompiler et reflasher l'ESP32.
+
 ## 3) SD et lecteur audio
 
 1. Inserer une SD avec au moins un fichier audio supporte a la racine (`.mp3`, `.wav`, `.aac`, `.flac`, `.opus`, `.ogg`).

--- a/hardware/firmware/esp32/src/story/README.md
+++ b/hardware/firmware/esp32/src/story/README.md
@@ -95,6 +95,8 @@ Diagnostic:
 Compat legacy conservee pendant PR1 via feature flag:
 
 - default compile-time: `config::kStoryV2EnabledDefault = false`
+- rollback runtime: `STORY_V2_ENABLE OFF`
+- rollback release: garder `kStoryV2EnabledDefault=false` puis recompiler/reflasher
 
 ## Creation d'un nouveau scenario
 


### PR DESCRIPTION
## Scope\n- Intègre le commit doc rollback Story V2 sur base codex\n- Fichiers: README.md, TESTING.md, src/story/README.md\n\n## Validation\n- Doc only change\n- Aucun impact binaire firmware\n