### PR TITLE
qa(live): rapport J5 USB Story V2

### DIFF
--- a/hardware/firmware/esp32/reports/live_j5_2026-02-13.md
+++ b/hardware/firmware/esp32/reports/live_j5_2026-02-13.md
@@ -1,0 +1,142 @@
+# Rapport Live USB J5 — 2026-02-13
+
+## Contexte
+
+- Branche testee: `qa/live-j5-report-20260213` (base `origin/codex/esp32-audio-mozzi-20260213`)
+- Firmware Story V2: commandes canoniques actives
+- Feature flag compile-time: `kStoryV2EnabledDefault=false`
+
+## 1) Preflight
+
+Commandes executees:
+
+```bash
+pio device list
+make qa-story-v2
+```
+
+Resultat: `PASS`
+
+- `qa-story-v2` termine avec `[qa-story-v2] OK`
+- Build matrix OK:
+  - `esp32dev`
+  - `esp8266_oled`
+  - `screen_esp8266_hw630:nodemcuv2`
+
+## 2) Mapping ports (detection automatique)
+
+Sonde esptool executee sur les ports CP2102:
+
+- ESP32 detecte sur:
+  - `/dev/cu.SLAB_USBtoUART`
+  - alias: `/dev/cu.usbserial-0001`
+  - MAC: `a0:b7:65:e7:f6:44`
+- ESP8266 detecte sur:
+  - `/dev/cu.SLAB_USBtoUART7`
+  - alias: `/dev/cu.usbserial-5`
+  - MAC: `84:f3:eb:0c:a0:e0`
+
+Resultat: `PASS`
+
+## 3) Flash sequentiel
+
+Commandes executees:
+
+```bash
+make upload-esp32 ESP32_PORT=/dev/cu.SLAB_USBtoUART
+make uploadfs-esp32 ESP32_PORT=/dev/cu.SLAB_USBtoUART
+make upload-screen SCREEN_PORT=/dev/cu.SLAB_USBtoUART7
+```
+
+Resultat: `PASS`
+
+- Upload firmware ESP32: OK
+- Upload LittleFS ESP32: OK
+- Upload firmware ESP8266 OLED: OK
+
+## 4) Runtime Story V2 (serial ESP32)
+
+Sequence executee:
+
+- `BOOT_STATUS`
+- `BOOT_REPLAY`
+- `BOOT_TEST_TONE`
+- `BOOT_TEST_DIAG`
+- `STORY_V2_ENABLE ON`
+- `STORY_V2_TRACE ON`
+- `STORY_V2_STATUS`
+- `STORY_V2_LIST`
+- `STORY_V2_VALIDATE`
+- `STORY_V2_HEALTH`
+- `STORY_TEST_ON`
+- `STORY_TEST_DELAY 2500`
+- `STORY_ARM`
+- `STORY_V2_EVENT ETAPE2_DUE`
+- `STORY_V2_STATUS`
+- `STORY_V2_HEALTH`
+- `STORY_V2_EVENT ETAPE2_DUE` (x20)
+- `STORY_V2_HEALTH`
+- `STORY_V2_TRACE OFF`
+- `STORY_TEST_OFF`
+- `STORY_STATUS`
+
+Resultat: `PASS`
+
+Preuves observees:
+
+- Validation scenario: `[STORY_V2] OK valid`
+- Progression steps:
+  - `STEP_WAIT_UNLOCK -> STEP_WIN`
+  - `STEP_WIN -> STEP_WAIT_ETAPE2`
+  - `STEP_WAIT_ETAPE2 -> STEP_ETAPE2`
+  - `STEP_ETAPE2 -> STEP_DONE`
+- Etat final: `step=STEP_DONE gate=1`
+- Health: `OK` puis `BUSY` transitoire attendu pendant transitions/audio
+
+## 5) Recovery lien ecran
+
+Test effectue:
+
+- reset ESP8266
+- reset ESP32
+- observation logs ESP32 + ESP8266
+
+Resultat: `PASS`
+
+Preuves observees:
+
+- cote ESP32: logs `SCREEN_SYNC` continus avant/apres reset
+- cote ESP32 apres reset local: boot complet et reprise emission trames
+- cote ESP8266: diagnostics avec `seq_gap`/`seq_rb` presents
+
+## 6) Statut tickets STV2-41..48
+
+- STV2-41: PASS
+- STV2-42: PASS
+- STV2-43: PASS
+- STV2-44: PASS
+- STV2-45: PASS
+- STV2-46: PASS (notes: `delay()` uniquement setup)
+- STV2-47: PASS
+- STV2-48: PASS
+
+## 7) Anomalies triees
+
+### Critique
+
+- Aucune
+
+### Majeure
+
+- Aucune
+
+### Mineure
+
+1. Traces `LOOP_BUDGET warn` ponctuelles (pics transitoires pendant transitions boot/story).
+2. Ligne serie ESP8266 occasionnellement corrompue juste apres reset (bruit UART au reboot), sans impact fonctionnel.
+
+## Conclusion
+
+- Validation live J5: `PASS`
+- Scenario Story V2 termine jusqu'a `STEP_DONE` avec gate MP3 ouvert.
+- Recovery ESP32/ESP8266 valide sans freeze detecte.


### PR DESCRIPTION
## Scope
- Ajoute le rapport live J5 du 2026-02-13
- Couvre preflight, mapping ports, flash, runtime Story V2, recovery lien ecran

## Resultat
- PASS global live J5
- Aucun blocage critique

## Fichier
- `hardware/firmware/esp32/reports/live_j5_2026-02-13.md`
