### PR TITLE
docs(process): cadence double flux + template PR + checklist STV2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Scope
+- [ ] Ticket(s) / sprint references:
+- [ ] Base branch cible (`main` ou `codex/*`):
+- [ ] Type de changement: code / docs / tests / infra
+
+## Implémentation
+- [ ] Contrats/API impactés listés
+- [ ] Compatibilité Story V2 / legacy vérifiée
+- [ ] Impact écran (STAT/seq/CRC) explicité
+
+## Validation
+- [ ] `make story-validate`
+- [ ] `make story-gen`
+- [ ] `make qa-story-v2`
+- [ ] `pio run -e esp32dev`
+- [ ] `pio run -e esp8266_oled`
+- [ ] `cd screen_esp8266_hw630 && pio run -e nodemcuv2`
+
+## Runtime live (si applicable)
+- [ ] Séquence Story V2 testée (`STEP_DONE` + `gate=1`)
+- [ ] Recovery reset croisé ESP32/ESP8266 validé
+
+## Rollback
+- [ ] Procédure runtime (`STORY_V2_ENABLE OFF`) documentée
+- [ ] Procédure release (`kStoryV2EnabledDefault=false`) documentée
+
+## Risques / points d’attention
+- [ ] Aucun
+- [ ] Oui (détailler):

--- a/hardware/firmware/esp32/README.md
+++ b/hardware/firmware/esp32/README.md
@@ -8,6 +8,15 @@ Ce dossier contient le firmware principal pour **ESP32 Audio Kit V2.2 A252**.
 - Dependances open source: voir `OPEN_SOURCE.md`
 - Politique de licence du depot: `../../../LICENSE.md`
 
+## Gouvernance branches (double flux)
+
+- Flux actifs: `main` et `codex/esp32-audio-mozzi-20260213`
+- Regle de sync hebdomadaire:
+  1. PR `sync/main-into-codex-<date>`
+  2. validation build matrix firmware
+  3. PR `sync/codex-into-main-<date>`
+- Toute PR sprint doit indiquer explicitement sa base (`main` ou `codex/*`) et le plan de resynchronisation.
+
 ## Profil cible
 
 - Carte: ESP32 Audio Kit V2.2 A252
@@ -161,6 +170,7 @@ Workflow auteur STORY V2:
 - `make story-validate` (strict)
 - `make story-gen` (strict + `spec_hash`)
 - `make qa-story-v2`
+- checklist review sprint: `tools/qa/story_v2_review_checklist.md`
 - `pio run -e esp32dev`
 
 Un nouveau scenario est ajoute via `story_specs/scenarios/*.yaml`, puis generation C++ dans `src/story/generated/*`.

--- a/hardware/firmware/esp32/tools/qa/story_v2_review_checklist.md
+++ b/hardware/firmware/esp32/tools/qa/story_v2_review_checklist.md
@@ -1,0 +1,84 @@
+# Checklist review STORY V2 (STV2-41..48)
+
+A utiliser a chaque sprint pour valider la non-regression Story V2.
+
+## STV2-41 — Routage serie Story V2
+
+- [ ] `serialProcessStoryCommand` est utilise comme point central
+- [ ] `app_orchestrator` ne contient pas de parsing Story V2 ad hoc
+- Preuve:
+```bash
+rg -n "serialProcessStoryCommand|makeStorySerialRuntimeContext" src/app/app_orchestrator.cpp src/services/serial/serial_commands_story.cpp
+```
+
+## STV2-42 — Snapshot et health
+
+- [ ] `StoryControllerV2Snapshot` expose les champs attendus
+- [ ] `STORY_V2_HEALTH` retourne une ligne exploitable
+- Preuve:
+```bash
+rg -n "StoryControllerV2Snapshot|healthLabel|STORY_V2_HEALTH" src/controllers/story src/services/serial/serial_commands_story.cpp
+```
+
+## STV2-43 — Hardening events/timers
+
+- [ ] budget events par tick en place
+- [ ] comptage drop queue en place
+- [ ] garde anti-tempete en place
+- Preuve:
+```bash
+rg -n "EVENT_BUDGET|droppedCount|isDuplicateStormEvent|kEventProcessBudgetPerUpdate" src/story/core src/controllers/story
+```
+
+## STV2-44 — story_gen strict + determinisme
+
+- [ ] validation stricte active
+- [ ] generation stable (idempotence)
+- [ ] hash spec present
+- Preuve:
+```bash
+make story-validate
+make story-gen
+make qa-story-v2
+```
+
+## STV2-45 — Robustesse lien ecran
+
+- [ ] keyframe/watchdog/stats TX actifs
+- [ ] parser ESP8266 suit `seq_gap/seq_rb`
+- Preuve:
+```bash
+rg -n "kScreenKeyframePeriodMs|kScreenWatchdogMs|tx_drop|seq_gap|seq_rb" src/services/screen src/screen screen_esp8266_hw630/src/main.cpp
+```
+
+## STV2-46 — Non bloquant runtime
+
+- [ ] pas de `delay()` dans transitions metier
+- [ ] latence action->feedback conforme
+- Preuve:
+```bash
+rg -n "\\bdelay\\(" src/app/app_orchestrator.cpp src/controllers src/services src/story
+```
+
+## STV2-47 — Script QA binaire
+
+- [ ] `tools/qa/story_v2_ci.sh` rejouable
+- [ ] verdict clair PASS/FAIL
+- Preuve:
+```bash
+bash tools/qa/story_v2_ci.sh
+```
+
+## STV2-48 — Docs et rollback
+
+- [ ] commandes Story V2 et workflow doc alignes
+- [ ] rollback runtime/release explicitement documente
+- Preuve:
+```bash
+rg -n "STORY_V2_ENABLE|STORY_V2_HEALTH|STORY_V2_TRACE|story-gen|qa-story-v2|rollback" README.md TESTING.md src/story/README.md
+```
+
+## Verdict final
+
+- [ ] PASS global
+- [ ] BLOCKED (detail + action corrective)


### PR DESCRIPTION
## Scope
- Ajoute la regle de sync hebdomadaire main<->codex
- Ajoute un template PR standardise
- Ajoute une checklist review STV2-41..48 reutilisable

## Fichiers
- `hardware/firmware/esp32/README.md`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `hardware/firmware/esp32/tools/qa/story_v2_review_checklist.md`
