### PR TITLE
sync(main): intégrer rapports live et gouvernance Story V2 depuis codex

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Scope
+- [ ] Ticket(s) / sprint references:
+- [ ] Base branch cible (`main` ou `codex/*`):
+- [ ] Type de changement: code / docs / tests / infra
+
+## Implémentation
+- [ ] Contrats/API impactés listés
+- [ ] Compatibilité Story V2 / legacy vérifiée
+- [ ] Impact écran (STAT/seq/CRC) explicité
+
+## Validation
+- [ ] `make story-validate`
+- [ ] `make story-gen`
+- [ ] `make qa-story-v2`
+- [ ] `pio run -e esp32dev`
+- [ ] `pio run -e esp8266_oled`
+- [ ] `cd screen_esp8266_hw630 && pio run -e nodemcuv2`
+
+## Runtime live (si applicable)
+- [ ] Séquence Story V2 testée (`STEP_DONE` + `gate=1`)
+- [ ] Recovery reset croisé ESP32/ESP8266 validé
+
+## Rollback
+- [ ] Procédure runtime (`STORY_V2_ENABLE OFF`) documentée
+- [ ] Procédure release (`kStoryV2EnabledDefault=false`) documentée
+
+## Risques / points d’attention
+- [ ] Aucun
+- [ ] Oui (détailler):

--- a/hardware/firmware/esp32/README.md
+++ b/hardware/firmware/esp32/README.md
@@ -8,6 +8,15 @@ Ce dossier contient le firmware principal pour **ESP32 Audio Kit V2.2 A252**.
 - Dependances open source: voir `OPEN_SOURCE.md`
 - Politique de licence du depot: `../../../LICENSE.md`
 
+## Gouvernance branches (double flux)
+
+- Flux actifs: `main` et `codex/esp32-audio-mozzi-20260213`
+- Regle de sync hebdomadaire:
+  1. PR `sync/main-into-codex-<date>`
+  2. validation build matrix firmware
+  3. PR `sync/codex-into-main-<date>`
+- Toute PR sprint doit indiquer explicitement sa base (`main` ou `codex/*`) et le plan de resynchronisation.
+
 ## Profil cible
 
 - Carte: ESP32 Audio Kit V2.2 A252
@@ -161,6 +170,7 @@ Workflow auteur STORY V2:
 - `make story-validate` (strict)
 - `make story-gen` (strict + `spec_hash`)
 - `make qa-story-v2`
+- checklist review sprint: `tools/qa/story_v2_review_checklist.md`
 - `pio run -e esp32dev`
 
 Un nouveau scenario est ajoute via `story_specs/scenarios/*.yaml`, puis generation C++ dans `src/story/generated/*`.
@@ -257,6 +267,7 @@ Sans variable `PORT`, PlatformIO choisit automatiquement le port serie.
 
 Astuce detection ports:
 - `pio device list`
+- Runbook semi-auto Story V2: `tools/qa/live_story_v2_runbook.md`
 
 ## Lecteur audio evolue
 

--- a/hardware/firmware/esp32/TESTING.md
+++ b/hardware/firmware/esp32/TESTING.md
@@ -25,6 +25,10 @@ Cette checklist couvre le comportement attendu du couple ESP32 + ESP8266 OLED.
    - `pio device monitor -e esp32dev --port <PORT_ESP32>`
    - `pio device monitor -e esp8266_oled --port <PORT_ESP8266>`
 
+Runbook live semi-automatique disponible:
+
+- `tools/qa/live_story_v2_runbook.md`
+
 ## 0) Tooling STORY V2 (hors carte)
 
 1. Validation stricte:

--- a/hardware/firmware/esp32/reports/live_j5_2026-02-13.md
+++ b/hardware/firmware/esp32/reports/live_j5_2026-02-13.md
@@ -1,0 +1,142 @@
+# Rapport Live USB J5 — 2026-02-13
+
+## Contexte
+
+- Branche testee: `qa/live-j5-report-20260213` (base `origin/codex/esp32-audio-mozzi-20260213`)
+- Firmware Story V2: commandes canoniques actives
+- Feature flag compile-time: `kStoryV2EnabledDefault=false`
+
+## 1) Preflight
+
+Commandes executees:
+
+```bash
+pio device list
+make qa-story-v2
+```
+
+Resultat: `PASS`
+
+- `qa-story-v2` termine avec `[qa-story-v2] OK`
+- Build matrix OK:
+  - `esp32dev`
+  - `esp8266_oled`
+  - `screen_esp8266_hw630:nodemcuv2`
+
+## 2) Mapping ports (detection automatique)
+
+Sonde esptool executee sur les ports CP2102:
+
+- ESP32 detecte sur:
+  - `/dev/cu.SLAB_USBtoUART`
+  - alias: `/dev/cu.usbserial-0001`
+  - MAC: `a0:b7:65:e7:f6:44`
+- ESP8266 detecte sur:
+  - `/dev/cu.SLAB_USBtoUART7`
+  - alias: `/dev/cu.usbserial-5`
+  - MAC: `84:f3:eb:0c:a0:e0`
+
+Resultat: `PASS`
+
+## 3) Flash sequentiel
+
+Commandes executees:
+
+```bash
+make upload-esp32 ESP32_PORT=/dev/cu.SLAB_USBtoUART
+make uploadfs-esp32 ESP32_PORT=/dev/cu.SLAB_USBtoUART
+make upload-screen SCREEN_PORT=/dev/cu.SLAB_USBtoUART7
+```
+
+Resultat: `PASS`
+
+- Upload firmware ESP32: OK
+- Upload LittleFS ESP32: OK
+- Upload firmware ESP8266 OLED: OK
+
+## 4) Runtime Story V2 (serial ESP32)
+
+Sequence executee:
+
+- `BOOT_STATUS`
+- `BOOT_REPLAY`
+- `BOOT_TEST_TONE`
+- `BOOT_TEST_DIAG`
+- `STORY_V2_ENABLE ON`
+- `STORY_V2_TRACE ON`
+- `STORY_V2_STATUS`
+- `STORY_V2_LIST`
+- `STORY_V2_VALIDATE`
+- `STORY_V2_HEALTH`
+- `STORY_TEST_ON`
+- `STORY_TEST_DELAY 2500`
+- `STORY_ARM`
+- `STORY_V2_EVENT ETAPE2_DUE`
+- `STORY_V2_STATUS`
+- `STORY_V2_HEALTH`
+- `STORY_V2_EVENT ETAPE2_DUE` (x20)
+- `STORY_V2_HEALTH`
+- `STORY_V2_TRACE OFF`
+- `STORY_TEST_OFF`
+- `STORY_STATUS`
+
+Resultat: `PASS`
+
+Preuves observees:
+
+- Validation scenario: `[STORY_V2] OK valid`
+- Progression steps:
+  - `STEP_WAIT_UNLOCK -> STEP_WIN`
+  - `STEP_WIN -> STEP_WAIT_ETAPE2`
+  - `STEP_WAIT_ETAPE2 -> STEP_ETAPE2`
+  - `STEP_ETAPE2 -> STEP_DONE`
+- Etat final: `step=STEP_DONE gate=1`
+- Health: `OK` puis `BUSY` transitoire attendu pendant transitions/audio
+
+## 5) Recovery lien ecran
+
+Test effectue:
+
+- reset ESP8266
+- reset ESP32
+- observation logs ESP32 + ESP8266
+
+Resultat: `PASS`
+
+Preuves observees:
+
+- cote ESP32: logs `SCREEN_SYNC` continus avant/apres reset
+- cote ESP32 apres reset local: boot complet et reprise emission trames
+- cote ESP8266: diagnostics avec `seq_gap`/`seq_rb` presents
+
+## 6) Statut tickets STV2-41..48
+
+- STV2-41: PASS
+- STV2-42: PASS
+- STV2-43: PASS
+- STV2-44: PASS
+- STV2-45: PASS
+- STV2-46: PASS (notes: `delay()` uniquement setup)
+- STV2-47: PASS
+- STV2-48: PASS
+
+## 7) Anomalies triees
+
+### Critique
+
+- Aucune
+
+### Majeure
+
+- Aucune
+
+### Mineure
+
+1. Traces `LOOP_BUDGET warn` ponctuelles (pics transitoires pendant transitions boot/story).
+2. Ligne serie ESP8266 occasionnellement corrompue juste apres reset (bruit UART au reboot), sans impact fonctionnel.
+
+## Conclusion
+
+- Validation live J5: `PASS`
+- Scenario Story V2 termine jusqu'a `STEP_DONE` avec gate MP3 ouvert.
+- Recovery ESP32/ESP8266 valide sans freeze detecte.

--- a/hardware/firmware/esp32/tools/qa/live_story_v2_runbook.md
+++ b/hardware/firmware/esp32/tools/qa/live_story_v2_runbook.md
@@ -1,0 +1,119 @@
+# Live Story V2 Runbook (semi-auto)
+
+Objectif: rejouer rapidement la validation terrain Story V2 (USB, flash, runtime, recovery).
+
+## 0) Prerequis
+
+- Deux cartes connectees en USB (ESP32 + ESP8266)
+- Depuis `hardware/firmware/esp32`
+- Python PlatformIO env disponible: `~/.platformio/penv/bin/python`
+
+## 1) Preflight statique
+
+```bash
+pio device list
+make qa-story-v2
+```
+
+Attendu: `[qa-story-v2] OK`.
+
+## 2) Mapping ports automatique
+
+```bash
+for p in /dev/cu.SLAB_USBtoUART /dev/cu.SLAB_USBtoUART7 /dev/cu.usbserial-0001 /dev/cu.usbserial-5; do
+  echo "=== $p (esp32 probe) ==="
+  ~/.platformio/penv/bin/python ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp32 --port "$p" --before default_reset --after no_reset chip_id || true
+  echo "=== $p (esp8266 probe) ==="
+  ~/.platformio/penv/bin/python ~/.platformio/packages/tool-esptoolpy/esptool.py --chip esp8266 --port "$p" --before default_reset --after no_reset flash_id || true
+done
+```
+
+Attendu:
+
+- 1 port ESP32 detecte
+- 1 port ESP8266 detecte
+
+## 3) Flash sequentiel
+
+Remplacer `<PORT_ESP32>` et `<PORT_ESP8266>`:
+
+```bash
+make upload-esp32 ESP32_PORT=<PORT_ESP32>
+make uploadfs-esp32 ESP32_PORT=<PORT_ESP32>
+make upload-screen SCREEN_PORT=<PORT_ESP8266>
+```
+
+## 4) Runtime Story V2 (script serie)
+
+Script copiable:
+
+```bash
+~/.platformio/penv/bin/python - <<'PY'
+import time
+import serial
+
+ESP32='/dev/cu.SLAB_USBtoUART'  # adapter
+BAUD=115200
+
+commands = [
+    'BOOT_STATUS','BOOT_REPLAY','BOOT_TEST_TONE','BOOT_TEST_DIAG',
+    'STORY_V2_ENABLE ON','STORY_V2_TRACE ON','STORY_V2_STATUS','STORY_V2_LIST',
+    'STORY_V2_VALIDATE','STORY_V2_HEALTH','STORY_TEST_ON','STORY_TEST_DELAY 2500',
+    'STORY_ARM','STORY_V2_EVENT ETAPE2_DUE','STORY_V2_STATUS','STORY_V2_HEALTH',
+]
+commands += ['STORY_V2_EVENT ETAPE2_DUE'] * 20
+commands += ['STORY_V2_HEALTH','STORY_V2_TRACE OFF','STORY_TEST_OFF','STORY_STATUS']
+
+with serial.Serial(ESP32, BAUD, timeout=0.2) as ser:
+    time.sleep(1)
+    end=time.time()+4
+    while time.time()<end:
+        b=ser.readline()
+        if b:
+            print(b.decode('utf-8',errors='replace').rstrip())
+
+    for cmd in commands:
+        print('>>>', cmd)
+        ser.write((cmd+'\n').encode())
+        ser.flush()
+        time.sleep(0.2)
+        end=time.time()+1.8
+        got=False
+        while time.time()<end:
+            b=ser.readline()
+            if b:
+                got=True
+                print(b.decode('utf-8',errors='replace').rstrip())
+        if not got:
+            print('(no immediate response)')
+PY
+```
+
+Attendu:
+
+- `STORY_V2 OK valid`
+- transitions jusqu'a `STEP_DONE`
+- `gate=1` en fin
+
+## 5) Recovery test (reset croise)
+
+- Reset ESP8266: bouton reset carte
+- Observer logs ESP32: `SCREEN_SYNC` continue
+- Reset ESP32: bouton reset carte
+- Observer reprise ecran < 2s
+
+## 6) Troubleshooting rapide
+
+Si flash impossible:
+
+1. Refaire le mapping ports (section 2)
+2. ESP32: maintenir `BOOT`, appuyer `EN`, relacher `EN`, relacher `BOOT`, relancer upload
+3. ESP8266: maintenir `FLASH`, appuyer `RST`, relacher `RST`, relacher `FLASH`, relancer upload
+4. Reessayer avec alias de port (`/dev/cu.SLAB_*` vs `/dev/cu.usbserial-*`)
+
+Si commandes Story ne repondent pas:
+
+1. Verifier baud monitor: `115200`
+2. Envoyer `STORY_V2_ENABLE STATUS`
+3. Envoyer `STORY_V2_ENABLE ON`
+4. Relancer `STORY_V2_STATUS` puis `STORY_V2_VALIDATE`

--- a/hardware/firmware/esp32/tools/qa/story_v2_review_checklist.md
+++ b/hardware/firmware/esp32/tools/qa/story_v2_review_checklist.md
@@ -1,0 +1,84 @@
+# Checklist review STORY V2 (STV2-41..48)
+
+A utiliser a chaque sprint pour valider la non-regression Story V2.
+
+## STV2-41 — Routage serie Story V2
+
+- [ ] `serialProcessStoryCommand` est utilise comme point central
+- [ ] `app_orchestrator` ne contient pas de parsing Story V2 ad hoc
+- Preuve:
+```bash
+rg -n "serialProcessStoryCommand|makeStorySerialRuntimeContext" src/app/app_orchestrator.cpp src/services/serial/serial_commands_story.cpp
+```
+
+## STV2-42 — Snapshot et health
+
+- [ ] `StoryControllerV2Snapshot` expose les champs attendus
+- [ ] `STORY_V2_HEALTH` retourne une ligne exploitable
+- Preuve:
+```bash
+rg -n "StoryControllerV2Snapshot|healthLabel|STORY_V2_HEALTH" src/controllers/story src/services/serial/serial_commands_story.cpp
+```
+
+## STV2-43 — Hardening events/timers
+
+- [ ] budget events par tick en place
+- [ ] comptage drop queue en place
+- [ ] garde anti-tempete en place
+- Preuve:
+```bash
+rg -n "EVENT_BUDGET|droppedCount|isDuplicateStormEvent|kEventProcessBudgetPerUpdate" src/story/core src/controllers/story
+```
+
+## STV2-44 — story_gen strict + determinisme
+
+- [ ] validation stricte active
+- [ ] generation stable (idempotence)
+- [ ] hash spec present
+- Preuve:
+```bash
+make story-validate
+make story-gen
+make qa-story-v2
+```
+
+## STV2-45 — Robustesse lien ecran
+
+- [ ] keyframe/watchdog/stats TX actifs
+- [ ] parser ESP8266 suit `seq_gap/seq_rb`
+- Preuve:
+```bash
+rg -n "kScreenKeyframePeriodMs|kScreenWatchdogMs|tx_drop|seq_gap|seq_rb" src/services/screen src/screen screen_esp8266_hw630/src/main.cpp
+```
+
+## STV2-46 — Non bloquant runtime
+
+- [ ] pas de `delay()` dans transitions metier
+- [ ] latence action->feedback conforme
+- Preuve:
+```bash
+rg -n "\\bdelay\\(" src/app/app_orchestrator.cpp src/controllers src/services src/story
+```
+
+## STV2-47 — Script QA binaire
+
+- [ ] `tools/qa/story_v2_ci.sh` rejouable
+- [ ] verdict clair PASS/FAIL
+- Preuve:
+```bash
+bash tools/qa/story_v2_ci.sh
+```
+
+## STV2-48 — Docs et rollback
+
+- [ ] commandes Story V2 et workflow doc alignes
+- [ ] rollback runtime/release explicitement documente
+- Preuve:
+```bash
+rg -n "STORY_V2_ENABLE|STORY_V2_HEALTH|STORY_V2_TRACE|story-gen|qa-story-v2|rollback" README.md TESTING.md src/story/README.md
+```
+
+## Verdict final
+
+- [ ] PASS global
+- [ ] BLOCKED (detail + action corrective)


### PR DESCRIPTION
## Scope\n- Synchronise les ajouts codex vers main apres J5\n- Inclut: rapport live J5, runbook live QA, checklist STV2, template PR, gouvernance double flux\n\n## Validation\n- make qa-story-v2\n