### PR TITLE
MPRC-10/11: extraire les commandes MP3 serie et brancher Mp3Controller

### DIFF
--- a/hardware/firmware/esp32/src/app/app_orchestrator.cpp
+++ b/hardware/firmware/esp32/src/app/app_orchestrator.cpp
@@ -12,6 +12,7 @@
 #include "../audio/effects/audio_effect_id.h"
 #include "../audio/fm_radio_scan_fx.h"
 #include "../controllers/boot/boot_protocol_runtime.h"
+#include "../controllers/mp3/mp3_controller.h"
 #include "../controllers/story/story_controller.h"
 #include "../controllers/story/story_controller_v2.h"
 #include "../runtime/app_scheduler.h"
@@ -126,7 +127,6 @@ void startMicCalibration(uint32_t nowMs, const char* reason);
 bool processCodecDebugCommand(const char* cmd);
 void printCodecDebugHelp();
 void printMp3DebugHelp();
-bool processMp3DebugCommand(const char* cmd, uint32_t nowMs);
 void printStoryDebugHelp();
 void resetLaHoldProgress();
 void updateMp3FormatTest(uint32_t nowMs);
@@ -164,6 +164,7 @@ void cancelULockSearchSonarCue(const char* source);
 void serviceULockSearchSonarCue(uint32_t nowMs);
 void onSerialCommand(const SerialCommand& cmd, uint32_t nowMs, void* ctx);
 StorySerialRuntimeContext makeStorySerialRuntimeContext();
+Mp3SerialRuntimeContext makeMp3SerialRuntimeContext();
 bool isCanonicalSerialCommand(const char* token);
 bool commandMatches(const char* cmd, const char* token);
 
@@ -175,6 +176,11 @@ InputService& inputService() {
 AudioService& audioService() {
   static AudioService service(g_asyncAudio, g_bootRadioScanFx, g_mp3);
   return service;
+}
+
+Mp3Controller& mp3Controller() {
+  static Mp3Controller controller(g_mp3, g_playerUi);
+  return controller;
 }
 
 bool laDetectedHook() {
@@ -2150,7 +2156,9 @@ void printMp3DebugHelp() {
   Serial.println("[MP3_DBG] Cmd: MP3_BACKEND STATUS|SET AUTO|AUDIO_TOOLS|LEGACY | MP3_BACKEND_STATUS");
   Serial.println("[MP3_DBG] Cmd: MP3_SCAN START|STATUS|CANCEL|REBUILD | MP3_SCAN_PROGRESS");
   Serial.println("[MP3_DBG] Cmd: MP3_BROWSE LS [path] | MP3_BROWSE CD <path> | MP3_PLAY_PATH <path>");
-  Serial.println("[MP3_DBG] Cmd: MP3_UI PAGE NOW|BROWSE|QUEUE|SET | MP3_STATE SAVE|LOAD|RESET");
+  Serial.println(
+      "[MP3_DBG] Cmd: MP3_UI STATUS|PAGE NOW|BROWSE|QUEUE|SET | MP3_UI_STATUS | MP3_QUEUE_PREVIEW [n]");
+  Serial.println("[MP3_DBG] Cmd: MP3_CAPS | MP3_STATE SAVE|LOAD|RESET");
 }
 
 void stopMp3FormatTest(const char* reason) {
@@ -2233,370 +2241,66 @@ void printMp3SupportedSdList(uint32_t nowMs, const char* source) {
   printMp3BrowseList(source, currentBrowsePath(), 0U, 24U);
 }
 
-bool processMp3DebugCommand(const char* cmd, uint32_t nowMs) {
-  if (cmd == nullptr || cmd[0] == '\0') {
+bool startMp3FormatTestCommand(uint32_t nowMs, uint32_t dwellMs) {
+  if (dwellMs < 1600U) {
+    dwellMs = 1600U;
+  } else if (dwellMs > 15000U) {
+    dwellMs = 15000U;
+  }
+
+  forceUsonFunctionalForMp3Debug("serial_mp3_test");
+  g_mp3.requestStorageRefresh(false);
+  g_mp3.update(nowMs, false);
+  if (!g_mp3.isSdReady() || g_mp3.trackCount() == 0U) {
+    Serial.println("[MP3_TEST] START refuse: SD/tracks indisponibles.");
     return false;
   }
 
-  if (strcmp(cmd, "MP3_HELP") == 0) {
-    printMp3DebugHelp();
-    return true;
+  stopMp3FormatTest("restart");
+  g_mp3FormatTest.active = true;
+  g_mp3FormatTest.totalTracks = g_mp3.trackCount();
+  g_mp3FormatTest.testedTracks = 0;
+  g_mp3FormatTest.okTracks = 0;
+  g_mp3FormatTest.failTracks = 0;
+  g_mp3FormatTest.dwellMs = dwellMs;
+  g_mp3FormatTest.stageStartMs = nowMs;
+  g_mp3FormatTest.stageResultLogged = false;
+
+  g_mp3.selectTrackByIndex(0U, true);
+
+  Serial.printf("[MP3_TEST] START tracks=%u dwell=%lu ms\n",
+                static_cast<unsigned int>(g_mp3FormatTest.totalTracks),
+                static_cast<unsigned long>(g_mp3FormatTest.dwellMs));
+  printMp3Status("test_start");
+  return true;
+}
+
+bool allowMp3PlaybackNowHook() {
+  return g_mode == RuntimeMode::kMp3;
+}
+
+void setBrowsePathHook(const char* path) {
+  if (path == nullptr || path[0] == '\0') {
+    g_mp3BrowsePath = "/";
+    return;
   }
+  g_mp3BrowsePath = path;
+}
 
-  if (strcmp(cmd, "MP3_STATUS") == 0) {
-    printMp3Status("status");
-    return true;
-  }
+void stopOverlayFxHook(const char* reason) {
+  audioService().stopOverlay(reason);
+}
 
-  if (strcmp(cmd, "MP3_BACKEND_STATUS") == 0) {
-    printMp3BackendStatus("status");
-    return true;
-  }
+void forceUsonFunctionalHook(const char* source) {
+  forceUsonFunctionalForMp3Debug(source);
+}
 
-  if (commandMatches(cmd, "MP3_BACKEND")) {
-    const char* arg = cmd + strlen("MP3_BACKEND");
-    while (*arg == ' ') {
-      ++arg;
-    }
+void printMp3QueuePreviewHook(uint8_t count, const char* source) {
+  mp3Controller().printQueuePreview(Serial, count, source);
+}
 
-    if (arg[0] == '\0' || strcmp(arg, "STATUS") == 0) {
-      Serial.printf("[MP3_BACKEND] mode=%s active=%s err=%s\n",
-                    g_mp3.backendModeLabel(),
-                    g_mp3.activeBackendLabel(),
-                    g_mp3.lastBackendError());
-      return true;
-    }
-
-    char modeToken[24] = {};
-    if (sscanf(arg, "SET %23s", modeToken) == 1) {
-      PlayerBackendMode mode = PlayerBackendMode::kAutoFallback;
-      if (!parseBackendModeToken(modeToken, &mode)) {
-        Serial.printf("[MP3_BACKEND] BAD_ARGS mode=%s (AUTO|AUDIO_TOOLS|LEGACY)\n", modeToken);
-        return true;
-      }
-      g_mp3.setBackendMode(mode);
-      Serial.printf("[MP3_BACKEND] SET mode=%s\n", g_mp3.backendModeLabel());
-      printMp3Status("backend_set");
-      return true;
-    }
-
-    Serial.printf("[MP3_BACKEND] BAD_ARGS cmd=%s\n", cmd);
-    return true;
-  }
-
-  if (commandMatches(cmd, "MP3_SCAN")) {
-    const char* arg = cmd + strlen("MP3_SCAN");
-    while (*arg == ' ') {
-      ++arg;
-    }
-    if (arg[0] == '\0' || strcmp(arg, "STATUS") == 0) {
-      printMp3ScanStatus("status");
-      return true;
-    }
-    if (strcmp(arg, "START") == 0) {
-      g_mp3.requestCatalogScan(false);
-      g_mp3.update(nowMs, g_mode == RuntimeMode::kMp3);
-      printMp3ScanStatus("start");
-      return true;
-    }
-    if (strcmp(arg, "REBUILD") == 0) {
-      g_mp3.requestCatalogScan(true);
-      g_mp3.update(nowMs, g_mode == RuntimeMode::kMp3);
-      printMp3ScanStatus("rebuild");
-      return true;
-    }
-    if (strcmp(arg, "CANCEL") == 0) {
-      const bool canceled = g_mp3.cancelCatalogScan();
-      Serial.printf("[MP3_SCAN] %s\n", canceled ? "OK canceled" : "OUT_OF_CONTEXT idle");
-      return true;
-    }
-    Serial.printf("[MP3_SCAN] BAD_ARGS op=%s (START|STATUS|CANCEL|REBUILD)\n", arg);
-    return true;
-  }
-
-  if (strcmp(cmd, "MP3_SCAN_PROGRESS") == 0) {
-    printMp3ScanProgress("status");
-    return true;
-  }
-
-  if (commandMatches(cmd, "MP3_BROWSE")) {
-    const char* arg = cmd + strlen("MP3_BROWSE");
-    while (*arg == ' ') {
-      ++arg;
-    }
-    if (strncmp(arg, "LS", 2) == 0 && (arg[2] == '\0' || arg[2] == ' ')) {
-      const char* path = arg + 2;
-      while (*path == ' ') {
-        ++path;
-      }
-      printMp3BrowseList("ls", (path[0] == '\0') ? currentBrowsePath() : path, 0U, 12U);
-      return true;
-    }
-    if (strncmp(arg, "CD", 2) == 0 && (arg[2] == ' ' || arg[2] == '\0')) {
-      const char* path = arg + 2;
-      while (*path == ' ') {
-        ++path;
-      }
-      if (path[0] == '\0') {
-        Serial.println("[MP3_BROWSE] BAD_ARGS path required");
-        return true;
-      }
-      String normalizedPath(path);
-      if (!normalizedPath.startsWith("/")) {
-        normalizedPath = "/" + normalizedPath;
-      }
-      const uint16_t count = g_mp3.countTracks(normalizedPath.c_str());
-      if (count == 0U) {
-        Serial.printf("[MP3_BROWSE] NOT_FOUND path=%s\n", normalizedPath.c_str());
-        return true;
-      }
-      g_mp3BrowsePath = normalizedPath;
-      g_playerUi.setPage(PlayerUiPage::kBrowser);
-      Serial.printf("[MP3_BROWSE] CD path=%s count=%u\n",
-                    g_mp3BrowsePath.c_str(),
-                    static_cast<unsigned int>(count));
-      return true;
-    }
-    Serial.printf("[MP3_BROWSE] BAD_ARGS cmd=%s\n", cmd);
-    return true;
-  }
-
-  if (commandMatches(cmd, "MP3_PLAY_PATH")) {
-    const char* path = cmd + strlen("MP3_PLAY_PATH");
-    while (*path == ' ') {
-      ++path;
-    }
-    if (path[0] == '\0') {
-      Serial.println("[MP3_DBG] BAD_ARGS MP3_PLAY_PATH <path>");
-      return true;
-    }
-    if (!g_mp3.playPath(path)) {
-      Serial.printf("[MP3_DBG] NOT_FOUND path=%s\n", path);
-      return true;
-    }
-    printMp3Status("play_path");
-    return true;
-  }
-
-  if (commandMatches(cmd, "MP3_UI")) {
-    const char* arg = cmd + strlen("MP3_UI");
-    while (*arg == ' ') {
-      ++arg;
-    }
-    if (arg[0] == '\0' || strcmp(arg, "STATUS") == 0) {
-      Serial.printf("[MP3_UI] page=%s cursor=%u offset=%u\n",
-                    playerUiPageLabel(g_playerUi.page()),
-                    static_cast<unsigned int>(g_playerUi.cursor()),
-                    static_cast<unsigned int>(g_playerUi.offset()));
-      return true;
-    }
-
-    char pageToken[16] = {};
-    if (sscanf(arg, "PAGE %15s", pageToken) == 1) {
-      PlayerUiPage page = PlayerUiPage::kNowPlaying;
-      if (!parsePlayerUiPageToken(pageToken, &page)) {
-        Serial.printf("[MP3_UI] BAD_ARGS page=%s (NOW|BROWSE|QUEUE|SET)\n", pageToken);
-        return true;
-      }
-      setPlayerUiPage(page);
-      Serial.printf("[MP3_UI] PAGE %s\n", playerUiPageLabel(g_playerUi.page()));
-      return true;
-    }
-
-    Serial.printf("[MP3_UI] BAD_ARGS cmd=%s\n", cmd);
-    return true;
-  }
-
-  if (commandMatches(cmd, "MP3_STATE")) {
-    const char* arg = cmd + strlen("MP3_STATE");
-    while (*arg == ' ') {
-      ++arg;
-    }
-    if (strcmp(arg, "SAVE") == 0) {
-      Serial.printf("[MP3_STATE] SAVE %s\n", g_mp3.savePlayerState() ? "OK" : "FAILED");
-      return true;
-    }
-    if (strcmp(arg, "LOAD") == 0) {
-      const bool ok = g_mp3.loadPlayerState();
-      if (ok) {
-        g_mp3.requestStorageRefresh(false);
-        g_mp3.update(nowMs, g_mode == RuntimeMode::kMp3);
-      }
-      Serial.printf("[MP3_STATE] LOAD %s\n", ok ? "OK" : "FAILED");
-      return true;
-    }
-    if (strcmp(arg, "RESET") == 0) {
-      Serial.printf("[MP3_STATE] RESET %s\n", g_mp3.resetPlayerState() ? "OK" : "FAILED");
-      return true;
-    }
-    Serial.printf("[MP3_STATE] BAD_ARGS op=%s (SAVE|LOAD|RESET)\n", arg);
-    return true;
-  }
-
-  if (strcmp(cmd, "MP3_UNLOCK") == 0) {
-    forceUsonFunctionalForMp3Debug("serial_mp3_unlock");
-    g_mp3.requestStorageRefresh(false);
-    g_mp3.update(nowMs, false);
-    printMp3Status("unlock");
-    return true;
-  }
-
-  if (strcmp(cmd, "MP3_REFRESH") == 0) {
-    g_mp3.requestStorageRefresh(true);
-    g_mp3.update(nowMs, g_mode == RuntimeMode::kMp3);
-    printMp3Status("refresh");
-    return true;
-  }
-
-  if (strcmp(cmd, "MP3_LIST") == 0) {
-    printMp3SupportedSdList(nowMs, "list");
-    return true;
-  }
-
-  if (strcmp(cmd, "MP3_NEXT") == 0) {
-    g_mp3.nextTrack();
-    printMp3Status("next");
-    return true;
-  }
-
-  if (strcmp(cmd, "MP3_PREV") == 0) {
-    g_mp3.previousTrack();
-    printMp3Status("prev");
-    return true;
-  }
-
-  if (strcmp(cmd, "MP3_RESTART") == 0) {
-    g_mp3.restartTrack();
-    printMp3Status("restart");
-    return true;
-  }
-
-  int trackNum = 0;
-  if (sscanf(cmd, "MP3_PLAY %d", &trackNum) == 1) {
-    if (trackNum < 1) {
-      Serial.println("[MP3_DBG] MP3_PLAY invalide: track>=1.");
-      return true;
-    }
-    g_mp3.requestStorageRefresh(false);
-    g_mp3.update(nowMs, g_mode == RuntimeMode::kMp3);
-    const uint16_t count = g_mp3.trackCount();
-    if (!g_mp3.isSdReady() || count == 0) {
-      Serial.println("[MP3_DBG] MP3_PLAY refuse: SD/tracks indisponibles.");
-      return true;
-    }
-    if (trackNum > static_cast<int>(count)) {
-      Serial.printf("[MP3_DBG] MP3_PLAY refuse: track=%d > count=%u.\n",
-                    trackNum,
-                    static_cast<unsigned int>(count));
-      return true;
-    }
-
-    if (!g_mp3.selectTrackByIndex(static_cast<uint16_t>(trackNum - 1), true)) {
-      Serial.printf("[MP3_DBG] MP3_PLAY failed: idx=%d\n", trackNum - 1);
-      return true;
-    }
-    printMp3Status("play");
-    return true;
-  }
-
-  if (strcmp(cmd, "MP3_FX_STOP") == 0) {
-    audioService().stopOverlay("serial_mp3_fx_stop");
-    printMp3Status("fx_stop");
-    return true;
-  }
-
-  char modeToken[16] = {};
-  if (sscanf(cmd, "MP3_FX_MODE %15s", modeToken) == 1) {
-    if (strcmp(modeToken, "DUCKING") == 0) {
-      g_mp3.setFxMode(Mp3FxMode::kDucking);
-      Serial.println("[MP3_FX] mode=DUCKING");
-      printMp3Status("fx_mode");
-      return true;
-    }
-    if (strcmp(modeToken, "OVERLAY") == 0) {
-      g_mp3.setFxMode(Mp3FxMode::kOverlay);
-      Serial.println("[MP3_FX] mode=OVERLAY");
-      printMp3Status("fx_mode");
-      return true;
-    }
-    Serial.println("[MP3_FX] MP3_FX_MODE invalide: DUCKING|OVERLAY.");
-    return true;
-  }
-
-  int duckPct = -1;
-  int mixPct = -1;
-  if (sscanf(cmd, "MP3_FX_GAIN %d %d", &duckPct, &mixPct) == 2) {
-    if (duckPct < 0 || duckPct > 100 || mixPct < 0 || mixPct > 100) {
-      Serial.println("[MP3_FX] MP3_FX_GAIN invalide: 0..100 0..100.");
-      return true;
-    }
-    g_mp3.setFxDuckingGain(static_cast<float>(duckPct) / 100.0f);
-    g_mp3.setFxOverlayGain(static_cast<float>(mixPct) / 100.0f);
-    printMp3Status("fx_gain");
-    return true;
-  }
-
-  char fxToken[16] = {};
-  int fxDurationMs = 0;
-  if (sscanf(cmd, "MP3_FX %15s %d", fxToken, &fxDurationMs) >= 1) {
-    Mp3FxEffect effect = Mp3FxEffect::kFmSweep;
-    if (!parseMp3FxEffectToken(fxToken, &effect)) {
-      Serial.println("[MP3_FX] MP3_FX invalide: FM|SONAR|MORSE|WIN [ms].");
-      return true;
-    }
-
-    forceUsonFunctionalForMp3Debug("serial_mp3_fx");
-    g_mp3.requestStorageRefresh(false);
-    g_mp3.update(nowMs, g_mode == RuntimeMode::kMp3);
-    triggerMp3Fx(effect,
-                 (fxDurationMs > 0) ? static_cast<uint32_t>(fxDurationMs)
-                                    : static_cast<uint32_t>(config::kMp3FxDefaultDurationMs),
-                 "serial_mp3_fx");
-    printMp3Status("fx");
-    return true;
-  }
-
-  int dwellMs = 3500;
-  if (sscanf(cmd, "MP3_TEST_START %d", &dwellMs) >= 1) {
-    if (dwellMs < 1600) {
-      dwellMs = 1600;
-    } else if (dwellMs > 15000) {
-      dwellMs = 15000;
-    }
-
-    forceUsonFunctionalForMp3Debug("serial_mp3_test");
-    g_mp3.requestStorageRefresh(false);
-    g_mp3.update(nowMs, false);
-    if (!g_mp3.isSdReady() || g_mp3.trackCount() == 0) {
-      Serial.println("[MP3_TEST] START refuse: SD/tracks indisponibles.");
-      return true;
-    }
-
-    stopMp3FormatTest("restart");
-    g_mp3FormatTest.active = true;
-    g_mp3FormatTest.totalTracks = g_mp3.trackCount();
-    g_mp3FormatTest.testedTracks = 0;
-    g_mp3FormatTest.okTracks = 0;
-    g_mp3FormatTest.failTracks = 0;
-    g_mp3FormatTest.dwellMs = static_cast<uint32_t>(dwellMs);
-    g_mp3FormatTest.stageStartMs = nowMs;
-    g_mp3FormatTest.stageResultLogged = false;
-
-    g_mp3.selectTrackByIndex(0U, true);
-
-    Serial.printf("[MP3_TEST] START tracks=%u dwell=%lu ms\n",
-                  static_cast<unsigned int>(g_mp3FormatTest.totalTracks),
-                  static_cast<unsigned long>(g_mp3FormatTest.dwellMs));
-    printMp3Status("test_start");
-    return true;
-  }
-
-  if (strcmp(cmd, "MP3_TEST_STOP") == 0) {
-    stopMp3FormatTest("serial_stop");
-    return true;
-  }
-
-  return false;
+void printMp3CapsHook(const char* source) {
+  mp3Controller().printCapabilities(Serial, source);
 }
 
 void updateMp3FormatTest(uint32_t nowMs) {
@@ -2759,6 +2463,33 @@ StorySerialRuntimeContext makeStorySerialRuntimeContext() {
   return context;
 }
 
+Mp3SerialRuntimeContext makeMp3SerialRuntimeContext() {
+  Mp3SerialRuntimeContext context = {};
+  context.player = &g_mp3;
+  context.ui = &g_playerUi;
+  context.allowPlaybackNow = allowMp3PlaybackNowHook;
+  context.setUiPage = setPlayerUiPage;
+  context.parsePlayerUiPageToken = parsePlayerUiPageToken;
+  context.parseBackendModeToken = parseBackendModeToken;
+  context.parseMp3FxEffectToken = parseMp3FxEffectToken;
+  context.triggerMp3Fx = triggerMp3Fx;
+  context.stopOverlayFx = stopOverlayFxHook;
+  context.forceUsonFunctional = forceUsonFunctionalHook;
+  context.currentBrowsePath = currentBrowsePath;
+  context.setBrowsePath = setBrowsePathHook;
+  context.printHelp = printMp3DebugHelp;
+  context.printStatus = printMp3Status;
+  context.printScanStatus = printMp3ScanStatus;
+  context.printScanProgress = printMp3ScanProgress;
+  context.printBackendStatus = printMp3BackendStatus;
+  context.printBrowseList = printMp3BrowseList;
+  context.printQueuePreview = printMp3QueuePreviewHook;
+  context.printCaps = printMp3CapsHook;
+  context.startFormatTest = startMp3FormatTestCommand;
+  context.stopFormatTest = stopMp3FormatTest;
+  return context;
+}
+
 void printKeyTuneHelp() {
   Serial.println("[KEY_TUNE] Cmd: KEY_STATUS | KEY_RAW_ON | KEY_RAW_OFF | KEY_RESET");
   Serial.println("[KEY_TUNE] Cmd: KEY_SET K4 1500 | KEY_SET K6 2200 | KEY_SET REL 3920");
@@ -2775,7 +2506,7 @@ void printKeyTuneHelp() {
   Serial.println("[KEY_TUNE] Cmd: STORY_V2_EVENT <name> | STORY_V2_STEP <id> | STORY_V2_SCENARIO <id>");
   Serial.println("[KEY_TUNE] Cmd: CODEC_STATUS | CODEC_DUMP | CODEC_RD/WR | CODEC_VOL");
   Serial.println("[KEY_TUNE] Cmd: MP3_STATUS | MP3_UNLOCK | MP3_REFRESH | MP3_LIST | MP3_TEST_START | MP3_FX");
-  Serial.println("[KEY_TUNE] Cmd: MP3_SCAN_PROGRESS | MP3_BACKEND_STATUS");
+  Serial.println("[KEY_TUNE] Cmd: MP3_SCAN_PROGRESS | MP3_BACKEND_STATUS | MP3_UI_STATUS | MP3_QUEUE_PREVIEW | MP3_CAPS");
   Serial.println("[KEY_TUNE] Cmd: SYS_LOOP_BUDGET STATUS|RESET | SCREEN_LINK_STATUS | SCREEN_LINK_RESET_STATS");
 }
 
@@ -2950,7 +2681,8 @@ bool isCanonicalSerialCommand(const char* token) {
       "MP3_FX",                     "MP3_FX_STOP",     "MP3_TEST_START", "MP3_TEST_STOP",
       "MP3_BACKEND",                "MP3_BACKEND_STATUS", "MP3_SCAN", "MP3_SCAN_PROGRESS",
       "MP3_BROWSE",                 "MP3_PLAY_PATH",
-      "MP3_UI",                     "MP3_STATE",
+      "MP3_UI",                     "MP3_UI_STATUS",   "MP3_QUEUE_PREVIEW",
+      "MP3_CAPS",                   "MP3_STATE",
       "KEY_HELP",                   "KEY_STATUS",      "KEY_RAW_ON",  "KEY_RAW_OFF",
       "KEY_RESET",                  "KEY_SET",         "KEY_SET_ALL", "KEY_TEST_START",
       "KEY_TEST_STATUS",            "KEY_TEST_RESET",  "KEY_TEST_STOP", "CODEC_HELP",
@@ -2996,7 +2728,8 @@ void onSerialCommand(const SerialCommand& cmd, uint32_t nowMs, void* ctx) {
     return;
   }
   if (serialIsMp3Command(cmd.token)) {
-    if (!processMp3DebugCommand(routedCmd, nowMs)) {
+    const Mp3SerialRuntimeContext context = makeMp3SerialRuntimeContext();
+    if (!serialProcessMp3Command(cmd, nowMs, context, Serial)) {
       serialDispatchReply(Serial, "MP3", SerialDispatchResult::kUnknown, cmd.line);
     }
     return;
@@ -3444,7 +3177,8 @@ void app_orchestrator::setup() {
   Serial.println(
       "[MP3_DBG] Serial: MP3_BACKEND STATUS|SET AUTO|AUDIO_TOOLS|LEGACY | MP3_BACKEND_STATUS | MP3_SCAN START|STATUS|CANCEL|REBUILD | MP3_SCAN_PROGRESS");
   Serial.println(
-      "[MP3_DBG] Serial: MP3_BROWSE LS [path] | MP3_BROWSE CD <path> | MP3_PLAY_PATH <path> | MP3_UI PAGE ... | MP3_STATE SAVE|LOAD|RESET");
+      "[MP3_DBG] Serial: MP3_BROWSE LS [path] | MP3_BROWSE CD <path> | MP3_PLAY_PATH <path> | MP3_UI STATUS|PAGE ... | MP3_UI_STATUS");
+  Serial.println("[MP3_DBG] Serial: MP3_QUEUE_PREVIEW [n] | MP3_CAPS | MP3_STATE SAVE|LOAD|RESET");
   Serial.println("[SYS] Serial: SYS_LOOP_BUDGET STATUS|RESET | SCREEN_LINK_STATUS | SCREEN_LINK_RESET_STATS");
   Serial.println("[FS] Serial: BOOT_FS_INFO | BOOT_FS_LIST | BOOT_FS_TEST");
   Serial.printf("[FS] Boot FX path: %s (%s)\n",
@@ -3485,8 +3219,7 @@ void app_orchestrator::loop() {
   }
 
   if (schedule.runMp3Service) {
-    g_mp3.update(nowMs, schedule.allowMp3Playback);
-    g_playerUi.setBrowserBounds(g_mp3.trackCount());
+    mp3Controller().update(nowMs, schedule.allowMp3Playback);
     nowMs = millis();
   }
   applyRuntimeMode(schedulerSelectRuntimeMode(makeSchedulerInputs()));

--- a/hardware/firmware/esp32/src/controllers/mp3/mp3_controller.cpp
+++ b/hardware/firmware/esp32/src/controllers/mp3/mp3_controller.cpp
@@ -1,5 +1,7 @@
 #include "mp3_controller.h"
 
+#include <cstring>
+
 Mp3Controller::Mp3Controller(Mp3Player& player, PlayerUiModel& ui) : player_(player), ui_(ui) {}
 
 void Mp3Controller::update(uint32_t nowMs, bool allowPlayback) {
@@ -15,10 +17,76 @@ void Mp3Controller::applyUiAction(const UiAction& action) {
   ui_.applyAction(action);
 }
 
+void Mp3Controller::printUiStatus(Print& out, const char* source) const {
+  const char* safeSource = (source != nullptr && source[0] != '\0') ? source : "status";
+  out.printf("[MP3_UI] %s page=%s cursor=%u offset=%u tracks=%u\n",
+             safeSource,
+             playerUiPageLabel(ui_.page()),
+             static_cast<unsigned int>(ui_.cursor()),
+             static_cast<unsigned int>(ui_.offset()),
+             static_cast<unsigned int>(player_.trackCount()));
+}
+
+void Mp3Controller::printQueuePreview(Print& out, uint8_t count, const char* source) const {
+  const char* safeSource = (source != nullptr && source[0] != '\0') ? source : "preview";
+  const uint16_t total = player_.trackCount();
+  if (count == 0U) {
+    count = 5U;
+  } else if (count > 12U) {
+    count = 12U;
+  }
+
+  if (total == 0U) {
+    out.printf("[MP3_QUEUE] %s empty tracks=0\n", safeSource);
+    return;
+  }
+
+  uint16_t current = player_.currentTrackNumber();
+  if (current == 0U || current > total) {
+    current = 1U;
+  }
+  uint8_t emitted = 0U;
+  for (uint8_t i = 0U; i < count && i < total; ++i) {
+    const uint16_t nextOneBased = static_cast<uint16_t>(((current + i) % total) + 1U);
+    const TrackEntry* entry = player_.trackEntryByNumber(nextOneBased);
+    if (entry == nullptr) {
+      continue;
+    }
+    const char* title = (entry->title[0] != '\0') ? entry->title : entry->path;
+    out.printf("[MP3_QUEUE] %s #%u %s | %s\n",
+               safeSource,
+               static_cast<unsigned int>(nextOneBased),
+               title,
+               entry->codec[0] != '\0' ? entry->codec : "-");
+    ++emitted;
+  }
+
+  if (emitted == 0U) {
+    out.printf("[MP3_QUEUE] %s empty tracks=%u\n", safeSource, static_cast<unsigned int>(total));
+  }
+}
+
+void Mp3Controller::printCapabilities(Print& out, const char* source) const {
+  const char* safeSource = (source != nullptr && source[0] != '\0') ? source : "status";
+  out.printf(
+      "[MP3_CAPS] %s codecs=MP3,WAV,AAC,FLAC,OPUS tools=WAV legacy=MP3,WAV,AAC,FLAC,OPUS mode=%s active=%s\n",
+      safeSource,
+      player_.backendModeLabel(),
+      player_.activeBackendLabel());
+}
+
 Mp3Player& Mp3Controller::player() {
   return player_;
 }
 
 const Mp3Player& Mp3Controller::player() const {
   return player_;
+}
+
+PlayerUiModel& Mp3Controller::ui() {
+  return ui_;
+}
+
+const PlayerUiModel& Mp3Controller::ui() const {
+  return ui_;
 }

--- a/hardware/firmware/esp32/src/controllers/mp3/mp3_controller.h
+++ b/hardware/firmware/esp32/src/controllers/mp3/mp3_controller.h
@@ -12,9 +12,14 @@ class Mp3Controller {
   void update(uint32_t nowMs, bool allowPlayback);
   void refreshStorage();
   void applyUiAction(const UiAction& action);
+  void printUiStatus(Print& out, const char* source) const;
+  void printQueuePreview(Print& out, uint8_t count, const char* source) const;
+  void printCapabilities(Print& out, const char* source) const;
 
   Mp3Player& player();
   const Mp3Player& player() const;
+  PlayerUiModel& ui();
+  const PlayerUiModel& ui() const;
 
  private:
   Mp3Player& player_;

--- a/hardware/firmware/esp32/src/services/serial/serial_commands_mp3.cpp
+++ b/hardware/firmware/esp32/src/services/serial/serial_commands_mp3.cpp
@@ -1,7 +1,520 @@
 #include "serial_commands_mp3.h"
 
 #include <cstring>
+#include <cctype>
+#include <cstdio>
+
+#include "../../config.h"
+#include "serial_dispatch.h"
+
+namespace {
+
+const char* skipSpaces(const char* text) {
+  if (text == nullptr) {
+    return "";
+  }
+  while (*text != '\0' && isspace(static_cast<unsigned char>(*text)) != 0) {
+    ++text;
+  }
+  return text;
+}
+
+bool textEquals(const char* lhs, const char* rhs) {
+  if (lhs == nullptr || rhs == nullptr) {
+    return false;
+  }
+  return strcmp(lhs, rhs) == 0;
+}
+
+bool textEqualsIgnoreCase(const char* lhs, const char* rhs) {
+  if (lhs == nullptr || rhs == nullptr) {
+    return false;
+  }
+  while (*lhs != '\0' && *rhs != '\0') {
+    if (toupper(static_cast<unsigned char>(*lhs)) != toupper(static_cast<unsigned char>(*rhs))) {
+      return false;
+    }
+    ++lhs;
+    ++rhs;
+  }
+  return (*lhs == '\0' && *rhs == '\0');
+}
+
+bool allowPlayback(const Mp3SerialRuntimeContext& ctx) {
+  return (ctx.allowPlaybackNow != nullptr) ? ctx.allowPlaybackNow() : false;
+}
+
+void printUiStatus(Print& out, const Mp3SerialRuntimeContext& ctx, const char* source) {
+  if (ctx.ui == nullptr || ctx.player == nullptr) {
+    serialDispatchReply(out, "MP3_UI", SerialDispatchResult::kOutOfContext, "missing_context");
+    return;
+  }
+  out.printf("[MP3_UI] %s page=%s cursor=%u offset=%u tracks=%u\n",
+             source != nullptr ? source : "status",
+             playerUiPageLabel(ctx.ui->page()),
+             static_cast<unsigned int>(ctx.ui->cursor()),
+             static_cast<unsigned int>(ctx.ui->offset()),
+             static_cast<unsigned int>(ctx.player->trackCount()));
+}
+
+}  // namespace
 
 bool serialIsMp3Command(const char* token) {
   return token != nullptr && strncmp(token, "MP3_", 4U) == 0;
+}
+
+bool serialProcessMp3Command(const SerialCommand& cmd,
+                             uint32_t nowMs,
+                             const Mp3SerialRuntimeContext& ctx,
+                             Print& out) {
+  if (cmd.token == nullptr || cmd.token[0] == '\0' || ctx.player == nullptr) {
+    return false;
+  }
+
+  Mp3Player& player = *ctx.player;
+  PlayerUiModel* ui = ctx.ui;
+  const char* args = skipSpaces(cmd.args);
+
+  if (serialTokenEquals(cmd, "MP3_HELP")) {
+    if (ctx.printHelp != nullptr) {
+      ctx.printHelp();
+    }
+    serialDispatchReply(out, "MP3", SerialDispatchResult::kOk, "help");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_STATUS")) {
+    if (ctx.printStatus != nullptr) {
+      ctx.printStatus("status");
+    }
+    serialDispatchReply(out, "MP3", SerialDispatchResult::kOk, "status");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_BACKEND_STATUS")) {
+    if (ctx.printBackendStatus != nullptr) {
+      ctx.printBackendStatus("status");
+    }
+    serialDispatchReply(out, "MP3_BACKEND", SerialDispatchResult::kOk, "status");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_BACKEND")) {
+    if (args[0] == '\0' || textEqualsIgnoreCase(args, "STATUS")) {
+      out.printf("[MP3_BACKEND] mode=%s active=%s err=%s\n",
+                 player.backendModeLabel(),
+                 player.activeBackendLabel(),
+                 player.lastBackendError());
+      serialDispatchReply(out, "MP3_BACKEND", SerialDispatchResult::kOk, "status");
+      return true;
+    }
+
+    char modeToken[24] = {};
+    if (sscanf(args, "SET %23s", modeToken) == 1) {
+      PlayerBackendMode mode = PlayerBackendMode::kAutoFallback;
+      if (ctx.parseBackendModeToken == nullptr || !ctx.parseBackendModeToken(modeToken, &mode)) {
+        serialDispatchReply(out, "MP3_BACKEND", SerialDispatchResult::kBadArgs, "AUTO|AUDIO_TOOLS|LEGACY");
+        return true;
+      }
+      player.setBackendMode(mode);
+      out.printf("[MP3_BACKEND] SET mode=%s\n", player.backendModeLabel());
+      if (ctx.printStatus != nullptr) {
+        ctx.printStatus("backend_set");
+      }
+      serialDispatchReply(out, "MP3_BACKEND", SerialDispatchResult::kOk, player.backendModeLabel());
+      return true;
+    }
+
+    serialDispatchReply(out, "MP3_BACKEND", SerialDispatchResult::kBadArgs, "STATUS|SET <mode>");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_SCAN")) {
+    if (args[0] == '\0' || textEqualsIgnoreCase(args, "STATUS")) {
+      if (ctx.printScanStatus != nullptr) {
+        ctx.printScanStatus("status");
+      }
+      serialDispatchReply(out, "MP3_SCAN", SerialDispatchResult::kOk, "status");
+      return true;
+    }
+    if (textEqualsIgnoreCase(args, "START")) {
+      player.requestCatalogScan(false);
+      player.update(nowMs, allowPlayback(ctx));
+      if (ctx.printScanStatus != nullptr) {
+        ctx.printScanStatus("start");
+      }
+      serialDispatchReply(out, "MP3_SCAN", SerialDispatchResult::kOk, "start");
+      return true;
+    }
+    if (textEqualsIgnoreCase(args, "REBUILD")) {
+      player.requestCatalogScan(true);
+      player.update(nowMs, allowPlayback(ctx));
+      if (ctx.printScanStatus != nullptr) {
+        ctx.printScanStatus("rebuild");
+      }
+      serialDispatchReply(out, "MP3_SCAN", SerialDispatchResult::kOk, "rebuild");
+      return true;
+    }
+    if (textEqualsIgnoreCase(args, "CANCEL")) {
+      const bool canceled = player.cancelCatalogScan();
+      serialDispatchReply(out,
+                          "MP3_SCAN",
+                          canceled ? SerialDispatchResult::kOk : SerialDispatchResult::kOutOfContext,
+                          canceled ? "canceled" : "idle");
+      return true;
+    }
+    serialDispatchReply(out, "MP3_SCAN", SerialDispatchResult::kBadArgs, "START|STATUS|CANCEL|REBUILD");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_SCAN_PROGRESS")) {
+    if (ctx.printScanProgress != nullptr) {
+      ctx.printScanProgress("status");
+    }
+    serialDispatchReply(out, "MP3_SCAN_PROGRESS", SerialDispatchResult::kOk, "status");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_BROWSE")) {
+    if (strncmp(args, "LS", 2) == 0 && (args[2] == '\0' || args[2] == ' ')) {
+      const char* path = skipSpaces(args + 2);
+      const char* target = (path[0] == '\0' && ctx.currentBrowsePath != nullptr) ? ctx.currentBrowsePath() : path;
+      if (ctx.printBrowseList != nullptr) {
+        ctx.printBrowseList("ls", target, 0U, 12U);
+      }
+      serialDispatchReply(out, "MP3_BROWSE", SerialDispatchResult::kOk, "ls");
+      return true;
+    }
+    if (strncmp(args, "CD", 2) == 0 && (args[2] == '\0' || args[2] == ' ')) {
+      const char* path = skipSpaces(args + 2);
+      if (path[0] == '\0') {
+        serialDispatchReply(out, "MP3_BROWSE", SerialDispatchResult::kBadArgs, "path required");
+        return true;
+      }
+      String normalized(path);
+      if (!normalized.startsWith("/")) {
+        normalized = "/" + normalized;
+      }
+      const uint16_t count = player.countTracks(normalized.c_str());
+      if (count == 0U) {
+        serialDispatchReply(out, "MP3_BROWSE", SerialDispatchResult::kNotFound, normalized.c_str());
+        return true;
+      }
+      if (ctx.setBrowsePath != nullptr) {
+        ctx.setBrowsePath(normalized.c_str());
+      }
+      if (ctx.setUiPage != nullptr) {
+        ctx.setUiPage(PlayerUiPage::kBrowser);
+      }
+      out.printf("[MP3_BROWSE] CD path=%s count=%u\n", normalized.c_str(), static_cast<unsigned int>(count));
+      serialDispatchReply(out, "MP3_BROWSE", SerialDispatchResult::kOk, "cd");
+      return true;
+    }
+    serialDispatchReply(out, "MP3_BROWSE", SerialDispatchResult::kBadArgs, "LS|CD");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_PLAY_PATH")) {
+    if (args[0] == '\0') {
+      serialDispatchReply(out, "MP3", SerialDispatchResult::kBadArgs, "MP3_PLAY_PATH <path>");
+      return true;
+    }
+    if (!player.playPath(args)) {
+      serialDispatchReply(out, "MP3", SerialDispatchResult::kNotFound, args);
+      return true;
+    }
+    if (ctx.printStatus != nullptr) {
+      ctx.printStatus("play_path");
+    }
+    serialDispatchReply(out, "MP3", SerialDispatchResult::kOk, "play_path");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_UI_STATUS")) {
+    printUiStatus(out, ctx, "status");
+    serialDispatchReply(out, "MP3_UI", SerialDispatchResult::kOk, "status");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_UI")) {
+    if (args[0] == '\0' || textEqualsIgnoreCase(args, "STATUS")) {
+      printUiStatus(out, ctx, "status");
+      serialDispatchReply(out, "MP3_UI", SerialDispatchResult::kOk, "status");
+      return true;
+    }
+
+    char pageToken[16] = {};
+    if (sscanf(args, "PAGE %15s", pageToken) == 1) {
+      PlayerUiPage page = PlayerUiPage::kNowPlaying;
+      if (ctx.parsePlayerUiPageToken == nullptr || !ctx.parsePlayerUiPageToken(pageToken, &page)) {
+        serialDispatchReply(out, "MP3_UI", SerialDispatchResult::kBadArgs, "NOW|BROWSE|QUEUE|SET");
+        return true;
+      }
+      if (ctx.setUiPage != nullptr) {
+        ctx.setUiPage(page);
+      } else if (ui != nullptr) {
+        ui->setPage(page);
+      }
+      out.printf("[MP3_UI] PAGE %s\n", (ui != nullptr) ? playerUiPageLabel(ui->page()) : playerUiPageLabel(page));
+      serialDispatchReply(out, "MP3_UI", SerialDispatchResult::kOk, "page");
+      return true;
+    }
+
+    serialDispatchReply(out, "MP3_UI", SerialDispatchResult::kBadArgs, "STATUS|PAGE <NOW|BROWSE|QUEUE|SET>");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_QUEUE_PREVIEW")) {
+    int count = 5;
+    if (args[0] != '\0' && sscanf(args, "%d", &count) != 1) {
+      serialDispatchReply(out, "MP3_QUEUE", SerialDispatchResult::kBadArgs, "[n]");
+      return true;
+    }
+    if (ctx.printQueuePreview != nullptr) {
+      ctx.printQueuePreview(static_cast<uint8_t>(count), "preview");
+      serialDispatchReply(out, "MP3_QUEUE", SerialDispatchResult::kOk, "preview");
+    } else {
+      serialDispatchReply(out, "MP3_QUEUE", SerialDispatchResult::kOutOfContext, "missing_callback");
+    }
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_CAPS")) {
+    if (ctx.printCaps != nullptr) {
+      ctx.printCaps("status");
+      serialDispatchReply(out, "MP3_CAPS", SerialDispatchResult::kOk, "status");
+    } else {
+      serialDispatchReply(out, "MP3_CAPS", SerialDispatchResult::kOutOfContext, "missing_callback");
+    }
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_STATE")) {
+    if (textEqualsIgnoreCase(args, "SAVE")) {
+      serialDispatchReply(out,
+                          "MP3_STATE",
+                          player.savePlayerState() ? SerialDispatchResult::kOk : SerialDispatchResult::kBusy,
+                          "save");
+      return true;
+    }
+    if (textEqualsIgnoreCase(args, "LOAD")) {
+      const bool ok = player.loadPlayerState();
+      if (ok) {
+        player.requestStorageRefresh(false);
+        player.update(nowMs, allowPlayback(ctx));
+      }
+      serialDispatchReply(out, "MP3_STATE", ok ? SerialDispatchResult::kOk : SerialDispatchResult::kBusy, "load");
+      return true;
+    }
+    if (textEqualsIgnoreCase(args, "RESET")) {
+      serialDispatchReply(out,
+                          "MP3_STATE",
+                          player.resetPlayerState() ? SerialDispatchResult::kOk : SerialDispatchResult::kBusy,
+                          "reset");
+      return true;
+    }
+    serialDispatchReply(out, "MP3_STATE", SerialDispatchResult::kBadArgs, "SAVE|LOAD|RESET");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_UNLOCK")) {
+    if (ctx.forceUsonFunctional != nullptr) {
+      ctx.forceUsonFunctional("serial_mp3_unlock");
+    }
+    player.requestStorageRefresh(false);
+    player.update(nowMs, false);
+    if (ctx.printStatus != nullptr) {
+      ctx.printStatus("unlock");
+    }
+    serialDispatchReply(out, "MP3", SerialDispatchResult::kOk, "unlock");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_REFRESH")) {
+    player.requestStorageRefresh(true);
+    player.update(nowMs, allowPlayback(ctx));
+    if (ctx.printStatus != nullptr) {
+      ctx.printStatus("refresh");
+    }
+    serialDispatchReply(out, "MP3", SerialDispatchResult::kOk, "refresh");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_LIST")) {
+    const char* browse = (ctx.currentBrowsePath != nullptr) ? ctx.currentBrowsePath() : "/";
+    if (ctx.printBrowseList != nullptr) {
+      ctx.printBrowseList("list", browse, 0U, 24U);
+    }
+    serialDispatchReply(out, "MP3", SerialDispatchResult::kOk, "list");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_NEXT")) {
+    player.nextTrack();
+    if (ctx.printStatus != nullptr) {
+      ctx.printStatus("next");
+    }
+    serialDispatchReply(out, "MP3", SerialDispatchResult::kOk, "next");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_PREV")) {
+    player.previousTrack();
+    if (ctx.printStatus != nullptr) {
+      ctx.printStatus("prev");
+    }
+    serialDispatchReply(out, "MP3", SerialDispatchResult::kOk, "prev");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_RESTART")) {
+    player.restartTrack();
+    if (ctx.printStatus != nullptr) {
+      ctx.printStatus("restart");
+    }
+    serialDispatchReply(out, "MP3", SerialDispatchResult::kOk, "restart");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_PLAY")) {
+    int trackNum = 0;
+    if (sscanf(args, "%d", &trackNum) != 1 || trackNum < 1) {
+      serialDispatchReply(out, "MP3", SerialDispatchResult::kBadArgs, "MP3_PLAY <track>=1");
+      return true;
+    }
+    player.requestStorageRefresh(false);
+    player.update(nowMs, allowPlayback(ctx));
+    const uint16_t count = player.trackCount();
+    if (!player.isSdReady() || count == 0U) {
+      serialDispatchReply(out, "MP3", SerialDispatchResult::kOutOfContext, "sd/tracks unavailable");
+      return true;
+    }
+    if (trackNum > static_cast<int>(count)) {
+      serialDispatchReply(out, "MP3", SerialDispatchResult::kBadArgs, "track>count");
+      return true;
+    }
+    if (!player.selectTrackByIndex(static_cast<uint16_t>(trackNum - 1), true)) {
+      serialDispatchReply(out, "MP3", SerialDispatchResult::kBusy, "select failed");
+      return true;
+    }
+    if (ctx.printStatus != nullptr) {
+      ctx.printStatus("play");
+    }
+    serialDispatchReply(out, "MP3", SerialDispatchResult::kOk, "play");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_FX_STOP")) {
+    if (ctx.stopOverlayFx != nullptr) {
+      ctx.stopOverlayFx("serial_mp3_fx_stop");
+    }
+    if (ctx.printStatus != nullptr) {
+      ctx.printStatus("fx_stop");
+    }
+    serialDispatchReply(out, "MP3_FX", SerialDispatchResult::kOk, "stop");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_FX_MODE")) {
+    char modeToken[16] = {};
+    if (sscanf(args, "%15s", modeToken) != 1) {
+      serialDispatchReply(out, "MP3_FX", SerialDispatchResult::kBadArgs, "DUCKING|OVERLAY");
+      return true;
+    }
+    if (textEqualsIgnoreCase(modeToken, "DUCKING")) {
+      player.setFxMode(Mp3FxMode::kDucking);
+      if (ctx.printStatus != nullptr) {
+        ctx.printStatus("fx_mode");
+      }
+      serialDispatchReply(out, "MP3_FX", SerialDispatchResult::kOk, "DUCKING");
+      return true;
+    }
+    if (textEqualsIgnoreCase(modeToken, "OVERLAY")) {
+      player.setFxMode(Mp3FxMode::kOverlay);
+      if (ctx.printStatus != nullptr) {
+        ctx.printStatus("fx_mode");
+      }
+      serialDispatchReply(out, "MP3_FX", SerialDispatchResult::kOk, "OVERLAY");
+      return true;
+    }
+    serialDispatchReply(out, "MP3_FX", SerialDispatchResult::kBadArgs, "DUCKING|OVERLAY");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_FX_GAIN")) {
+    int duckPct = -1;
+    int mixPct = -1;
+    if (sscanf(args, "%d %d", &duckPct, &mixPct) != 2) {
+      serialDispatchReply(out, "MP3_FX", SerialDispatchResult::kBadArgs, "<duck%> <mix%>");
+      return true;
+    }
+    if (duckPct < 0 || duckPct > 100 || mixPct < 0 || mixPct > 100) {
+      serialDispatchReply(out, "MP3_FX", SerialDispatchResult::kBadArgs, "0..100 0..100");
+      return true;
+    }
+    player.setFxDuckingGain(static_cast<float>(duckPct) / 100.0f);
+    player.setFxOverlayGain(static_cast<float>(mixPct) / 100.0f);
+    if (ctx.printStatus != nullptr) {
+      ctx.printStatus("fx_gain");
+    }
+    serialDispatchReply(out, "MP3_FX", SerialDispatchResult::kOk, "gain");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_FX")) {
+    char fxToken[16] = {};
+    int durationMs = static_cast<int>(config::kMp3FxDefaultDurationMs);
+    if (sscanf(args, "%15s %d", fxToken, &durationMs) < 1) {
+      serialDispatchReply(out, "MP3_FX", SerialDispatchResult::kBadArgs, "FM|SONAR|MORSE|WIN [ms]");
+      return true;
+    }
+    Mp3FxEffect effect = Mp3FxEffect::kFmSweep;
+    if (ctx.parseMp3FxEffectToken == nullptr || !ctx.parseMp3FxEffectToken(fxToken, &effect)) {
+      serialDispatchReply(out, "MP3_FX", SerialDispatchResult::kBadArgs, "FM|SONAR|MORSE|WIN");
+      return true;
+    }
+    if (ctx.forceUsonFunctional != nullptr) {
+      ctx.forceUsonFunctional("serial_mp3_fx");
+    }
+    player.requestStorageRefresh(false);
+    player.update(nowMs, allowPlayback(ctx));
+    const uint32_t safeDuration = (durationMs > 0) ? static_cast<uint32_t>(durationMs)
+                                                   : static_cast<uint32_t>(config::kMp3FxDefaultDurationMs);
+    const bool ok = (ctx.triggerMp3Fx != nullptr) && ctx.triggerMp3Fx(effect, safeDuration, "serial_mp3_fx");
+    if (ctx.printStatus != nullptr) {
+      ctx.printStatus("fx");
+    }
+    serialDispatchReply(out, "MP3_FX", ok ? SerialDispatchResult::kOk : SerialDispatchResult::kBusy, "trigger");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_TEST_START")) {
+    int dwellMs = 3500;
+    if (args[0] != '\0' && sscanf(args, "%d", &dwellMs) != 1) {
+      serialDispatchReply(out, "MP3_TEST", SerialDispatchResult::kBadArgs, "[ms]");
+      return true;
+    }
+    if (dwellMs < 1600) {
+      dwellMs = 1600;
+    } else if (dwellMs > 15000) {
+      dwellMs = 15000;
+    }
+    if (ctx.startFormatTest == nullptr) {
+      serialDispatchReply(out, "MP3_TEST", SerialDispatchResult::kOutOfContext, "missing_callback");
+      return true;
+    }
+    const bool ok = ctx.startFormatTest(nowMs, static_cast<uint32_t>(dwellMs));
+    serialDispatchReply(out, "MP3_TEST", ok ? SerialDispatchResult::kOk : SerialDispatchResult::kOutOfContext, "start");
+    return true;
+  }
+
+  if (serialTokenEquals(cmd, "MP3_TEST_STOP")) {
+    if (ctx.stopFormatTest != nullptr) {
+      ctx.stopFormatTest("serial_stop");
+    }
+    serialDispatchReply(out, "MP3_TEST", SerialDispatchResult::kOk, "stop");
+    return true;
+  }
+
+  return false;
 }

--- a/hardware/firmware/esp32/src/services/serial/serial_commands_mp3.h
+++ b/hardware/firmware/esp32/src/services/serial/serial_commands_mp3.h
@@ -2,4 +2,38 @@
 
 #include <Arduino.h>
 
+#include "../../audio/effects/audio_effect_id.h"
+#include "../../audio/mp3_player.h"
+#include "../../ui/player_ui_model.h"
+#include "serial_router.h"
+
+struct Mp3SerialRuntimeContext {
+  Mp3Player* player = nullptr;
+  PlayerUiModel* ui = nullptr;
+  bool (*allowPlaybackNow)() = nullptr;
+  bool (*setUiPage)(PlayerUiPage page) = nullptr;
+  bool (*parsePlayerUiPageToken)(const char* token, PlayerUiPage* outPage) = nullptr;
+  bool (*parseBackendModeToken)(const char* token, PlayerBackendMode* outMode) = nullptr;
+  bool (*parseMp3FxEffectToken)(const char* token, Mp3FxEffect* outEffect) = nullptr;
+  bool (*triggerMp3Fx)(Mp3FxEffect effect, uint32_t durationMs, const char* source) = nullptr;
+  void (*stopOverlayFx)(const char* reason) = nullptr;
+  void (*forceUsonFunctional)(const char* source) = nullptr;
+  const char* (*currentBrowsePath)() = nullptr;
+  void (*setBrowsePath)(const char* path) = nullptr;
+  void (*printHelp)() = nullptr;
+  void (*printStatus)(const char* source) = nullptr;
+  void (*printScanStatus)(const char* source) = nullptr;
+  void (*printScanProgress)(const char* source) = nullptr;
+  void (*printBackendStatus)(const char* source) = nullptr;
+  void (*printBrowseList)(const char* source, const char* path, uint16_t offset, uint16_t limit) = nullptr;
+  void (*printQueuePreview)(uint8_t count, const char* source) = nullptr;
+  void (*printCaps)(const char* source) = nullptr;
+  bool (*startFormatTest)(uint32_t nowMs, uint32_t dwellMs) = nullptr;
+  void (*stopFormatTest)(const char* reason) = nullptr;
+};
+
 bool serialIsMp3Command(const char* token);
+bool serialProcessMp3Command(const SerialCommand& cmd,
+                             uint32_t nowMs,
+                             const Mp3SerialRuntimeContext& ctx,
+                             Print& out);


### PR DESCRIPTION
## Scope
- extraction du dispatch MP3 serie depuis src/app/app_orchestrator.cpp vers src/services/serial/serial_commands_mp3.cpp
- introduction du contexte Mp3SerialRuntimeContext pour decoupler callbacks runtime
- wiring Mp3Controller dans la boucle app pour update MP3/UI
- ajout commandes MP3_UI_STATUS, MP3_QUEUE_PREVIEW, MP3_CAPS en canonique

## Verification
- pio run -e esp32dev
- pio run -e esp8266_oled
- cd screen_esp8266_hw630 && pio run -e nodemcuv2
- make story-validate
- make story-gen
- make qa-story-v2

## Notes
- le fichier local reports/live_story_v2_smoke_20260213_181353.log reste hors commit
