### PR TITLE
MPRC-20/21: scan catalogue MP3 non bloquant + progression enrichie

### DIFF
--- a/hardware/firmware/esp32/src/app/app_orchestrator.cpp
+++ b/hardware/firmware/esp32/src/app/app_orchestrator.cpp
@@ -503,6 +503,7 @@ uint8_t encodeMp3ErrorForScreen() {
 
 void printMp3ScanStatus(const char* source) {
   const CatalogStats stats = g_mp3.catalogStats();
+  const Mp3ScanProgress progress = g_mp3.scanProgress();
   Serial.printf("[MP3_SCAN] %s state=%s busy=%u tracks=%u folders=%u scan_ms=%lu indexed=%u metadata_best=%u\n",
                 source,
                 g_mp3.scanStateLabel(),
@@ -512,22 +513,39 @@ void printMp3ScanStatus(const char* source) {
                 static_cast<unsigned long>(stats.scanMs),
                 stats.indexed ? 1U : 0U,
                 stats.metadataBestEffort ? 1U : 0U);
+  Serial.printf(
+      "[MP3_SCAN] %s pending=%u force=%u reason=%s ticks=%lu elapsed=%lu budget_ms=%u entry_budget=%u\n",
+      source,
+      progress.pendingRequest ? 1U : 0U,
+      progress.forceRebuild ? 1U : 0U,
+      progress.reason,
+      static_cast<unsigned long>(progress.ticks),
+      static_cast<unsigned long>(progress.elapsedMs),
+      static_cast<unsigned int>(progress.tickBudgetMs),
+      static_cast<unsigned int>(progress.tickEntryBudget));
 }
 
 void printMp3ScanProgress(const char* source) {
   const Mp3ScanProgress progress = g_mp3.scanProgress();
   const CatalogStats stats = g_mp3.catalogStats();
   Serial.printf(
-      "[MP3_SCAN_PROGRESS] %s state=%s active=%u depth=%u stack=%u folders=%u files=%u tracks=%u limit=%u scan_ms=%lu\n",
+      "[MP3_SCAN_PROGRESS] %s state=%s active=%u pending=%u force=%u reason=%s depth=%u stack=%u folders=%u files=%u tracks=%u limit=%u tick_entries=%u tick_hits=%u ticks=%lu elapsed=%lu scan_ms=%lu\n",
       source,
       g_mp3.scanStateLabel(),
       progress.active ? 1U : 0U,
+      progress.pendingRequest ? 1U : 0U,
+      progress.forceRebuild ? 1U : 0U,
+      progress.reason,
       static_cast<unsigned int>(progress.depth),
       static_cast<unsigned int>(progress.stackSize),
       static_cast<unsigned int>(progress.foldersScanned),
       static_cast<unsigned int>(progress.filesScanned),
       static_cast<unsigned int>(progress.tracksAccepted),
       progress.limitReached ? 1U : 0U,
+      static_cast<unsigned int>(progress.entriesThisTick),
+      static_cast<unsigned int>(progress.entryBudgetHits),
+      static_cast<unsigned long>(progress.ticks),
+      static_cast<unsigned long>(progress.elapsedMs),
       static_cast<unsigned long>(stats.scanMs));
 }
 

--- a/hardware/firmware/esp32/src/audio/mp3_player.h
+++ b/hardware/firmware/esp32/src/audio/mp3_player.h
@@ -28,12 +28,21 @@ enum class RepeatMode : uint8_t {
 
 struct Mp3ScanProgress {
   bool active = false;
+  bool pendingRequest = false;
+  bool forceRebuild = false;
   bool limitReached = false;
   uint8_t depth = 0U;
   uint8_t stackSize = 0U;
   uint16_t foldersScanned = 0U;
   uint16_t filesScanned = 0U;
   uint16_t tracksAccepted = 0U;
+  uint16_t entriesThisTick = 0U;
+  uint16_t entryBudgetHits = 0U;
+  uint32_t ticks = 0U;
+  uint32_t elapsedMs = 0U;
+  uint16_t tickBudgetMs = 0U;
+  uint16_t tickEntryBudget = 0U;
+  char reason[24] = "IDLE";
 };
 
 struct Mp3BackendRuntimeStats {


### PR DESCRIPTION
## Scope
- renforce le scan catalogue MP3 non bloquant avec double budget par tick (temps + nombre d entrees)
- enrichit la telemetrie scan (`pendingRequest`, `forceRebuild`, `reason`, `ticks`, `elapsedMs`, budgets)
- enrichit les sorties serie `MP3_SCAN` et `MP3_SCAN_PROGRESS`

## Verification
- pio run -e esp32dev
- pio run -e esp8266_oled
- cd screen_esp8266_hw630 && pio run -e nodemcuv2
- make story-validate
- make story-gen
- make qa-story-v2

## Impact attendu
- pas de freeze input/serie pendant scan actif
- diagnostics scan plus exploitables en live
