### PR TITLE
MPRC-30/31/40/42: UX MP3 4 pages + trame ecran et profil release

### DIFF
--- a/hardware/firmware/esp32/platformio.ini
+++ b/hardware/firmware/esp32/platformio.ini
@@ -25,6 +25,15 @@ lib_deps =
   https://github.com/pschatzmann/arduino-audio-driver.git#84c7de2eb47efe43bcc769783bb1853ee8a32f21
 build_flags =
   -DCORE_DEBUG_LEVEL=1
+  -DUSON_STORY_V2_DEFAULT=1
+
+[env:esp32_release]
+extends = env:esp32dev
+build_unflags =
+  -DUSON_STORY_V2_DEFAULT=1
+build_flags =
+  ${env:esp32dev.build_flags}
+  -DUSON_STORY_V2_DEFAULT=0
 
 [env:esp8266_oled]
 platform = espressif8266

--- a/hardware/firmware/esp32/screen_esp8266_hw630/src/core/stat_parser.cpp
+++ b/hardware/firmware/esp32/screen_esp8266_hw630/src/core/stat_parser.cpp
@@ -58,10 +58,14 @@ bool parseStatFrame(const char* frame,
   unsigned int backendMode = 0;
   unsigned int scanBusy = 0;
   unsigned int errorCode = 0;
+  unsigned int uiCursor = 0;
+  unsigned int uiOffset = 0;
+  unsigned int uiCount = 0;
+  unsigned int queueCount = 0;
   unsigned int frameCrc = 0;
 
   const int parsed = sscanf(frame,
-                            "STAT,%u,%u,%u,%lu,%u,%u,%u,%u,%u,%u,%u,%d,%u,%u,%u,%u,%u,%u,%u,%lu,%u,%u,%u,%u,%u,%u,%x",
+                            "STAT,%u,%u,%u,%lu,%u,%u,%u,%u,%u,%u,%u,%d,%u,%u,%u,%u,%u,%u,%u,%lu,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%x",
                             &la,
                             &mp3,
                             &sd,
@@ -88,6 +92,10 @@ bool parseStatFrame(const char* frame,
                             &backendMode,
                             &scanBusy,
                             &errorCode,
+                            &uiCursor,
+                            &uiOffset,
+                            &uiCount,
+                            &queueCount,
                             &frameCrc);
   if (parsed < 19) {
     return false;
@@ -191,6 +199,10 @@ bool parseStatFrame(const char* frame,
   out->backendMode = (parsed >= 24) ? static_cast<uint8_t>(backendMode) : 0U;
   out->scanBusy = (parsed >= 25) ? (scanBusy != 0U) : false;
   out->errorCode = (parsed >= 26) ? static_cast<uint8_t>(errorCode) : 0U;
+  out->uiCursor = (parsed >= 27) ? static_cast<uint16_t>(uiCursor) : 0U;
+  out->uiOffset = (parsed >= 28) ? static_cast<uint16_t>(uiOffset) : 0U;
+  out->uiCount = (parsed >= 29) ? static_cast<uint16_t>(uiCount) : 0U;
+  out->queueCount = (parsed >= 30) ? static_cast<uint16_t>(queueCount) : 0U;
 
   out->lastRxMs = nowMs;
   return true;

--- a/hardware/firmware/esp32/screen_esp8266_hw630/src/core/telemetry_state.h
+++ b/hardware/firmware/esp32/screen_esp8266_hw630/src/core/telemetry_state.h
@@ -32,6 +32,10 @@ struct TelemetryState {
   uint8_t appStage = kAppStageULockWaiting;
   uint32_t frameSeq = 0;
   uint8_t uiPage = 0;
+  uint16_t uiCursor = 0;
+  uint16_t uiOffset = 0;
+  uint16_t uiCount = 0;
+  uint16_t queueCount = 0;
   uint8_t repeatMode = 0;
   bool fxActive = false;
   uint8_t backendMode = 0;

--- a/hardware/firmware/esp32/screen_esp8266_hw630/src/main.cpp
+++ b/hardware/firmware/esp32/screen_esp8266_hw630/src/main.cpp
@@ -597,6 +597,19 @@ const char* backendShortLabel(uint8_t backendMode) {
   }
 }
 
+const char* settingsShortLabel(uint16_t idx) {
+  switch (idx) {
+    case 0:
+      return "REPEAT";
+    case 1:
+      return "BACKEND";
+    case 2:
+      return "SCAN";
+    default:
+      return "-";
+  }
+}
+
 void renderMp3Screen() {
   drawTitleBar("LECTEUR U-SON");
 
@@ -607,7 +620,25 @@ void renderMp3Screen() {
                     15);
 
   char trackLine[20];
-  if (g_state.trackCount == 0) {
+  if (g_state.uiPage == 1U) {
+    const uint16_t cursor = (g_state.uiCursor < g_state.uiCount) ? g_state.uiCursor : 0U;
+    snprintf(trackLine,
+             sizeof(trackLine),
+             "BRW %u/%u",
+             static_cast<unsigned int>((g_state.uiCount == 0U) ? 0U : (cursor + 1U)),
+             static_cast<unsigned int>(g_state.uiCount));
+  } else if (g_state.uiPage == 2U) {
+    snprintf(trackLine,
+             sizeof(trackLine),
+             "QUE +%u/%u",
+             static_cast<unsigned int>(g_state.uiOffset),
+             static_cast<unsigned int>(g_state.queueCount));
+  } else if (g_state.uiPage == 3U) {
+    snprintf(trackLine,
+             sizeof(trackLine),
+             "SET %s",
+             settingsShortLabel(g_state.uiCursor));
+  } else if (g_state.trackCount == 0U) {
     snprintf(trackLine, sizeof(trackLine), "-- / --");
   } else {
     snprintf(trackLine,
@@ -619,7 +650,24 @@ void renderMp3Screen() {
   drawCenteredText(trackLine, 33, 1);
 
   char infoLine[32];
-  if (g_state.key == 0) {
+  if (g_state.uiPage == 1U) {
+    snprintf(infoLine,
+             sizeof(infoLine),
+             "CUR %u OFF %u",
+             static_cast<unsigned int>((g_state.uiCount == 0U) ? 0U : (g_state.uiCursor + 1U)),
+             static_cast<unsigned int>(g_state.uiOffset));
+  } else if (g_state.uiPage == 2U) {
+    snprintf(infoLine,
+             sizeof(infoLine),
+             "QUEUE +%u  N%u",
+             static_cast<unsigned int>(g_state.uiOffset),
+             static_cast<unsigned int>(g_state.queueCount));
+  } else if (g_state.uiPage == 3U) {
+    snprintf(infoLine,
+             sizeof(infoLine),
+             "K1 %s",
+             settingsShortLabel(g_state.uiCursor));
+  } else if (g_state.key == 0) {
     snprintf(infoLine,
              sizeof(infoLine),
              "VOL %u%%  SD %s",

--- a/hardware/firmware/esp32/src/config.h
+++ b/hardware/firmware/esp32/src/config.h
@@ -2,6 +2,10 @@
 
 #include <Arduino.h>
 
+#ifndef USON_STORY_V2_DEFAULT
+#define USON_STORY_V2_DEFAULT 1
+#endif
+
 namespace config {
 
 constexpr uint8_t kPinLedR = 16;
@@ -59,7 +63,7 @@ constexpr uint16_t kBootProtocolPromptPeriodMs = 3000;
 constexpr uint16_t kBootRadioScanChunkMs = 18;
 constexpr uint32_t kStoryEtape2DelayMs = 15UL * 60UL * 1000UL;
 constexpr uint32_t kStoryEtape2TestDelayMs = 5000U;
-constexpr bool kStoryV2EnabledDefault = true;
+constexpr bool kStoryV2EnabledDefault = (USON_STORY_V2_DEFAULT != 0);
 constexpr bool kEnableInternalLittleFs = true;
 constexpr bool kInternalLittleFsFormatOnFail = false;
 constexpr bool kPreferLittleFsBootFx = true;

--- a/hardware/firmware/esp32/src/controllers/mp3/mp3_controller.cpp
+++ b/hardware/firmware/esp32/src/controllers/mp3/mp3_controller.cpp
@@ -19,17 +19,21 @@ void Mp3Controller::applyUiAction(const UiAction& action) {
 
 void Mp3Controller::printUiStatus(Print& out, const char* source) const {
   const char* safeSource = (source != nullptr && source[0] != '\0') ? source : "status";
-  out.printf("[MP3_UI] %s page=%s cursor=%u offset=%u tracks=%u\n",
+  out.printf("[MP3_UI] %s page=%s cursor=%u offset=%u browse=%u queue_off=%u set_idx=%u tracks=%u\n",
              safeSource,
              playerUiPageLabel(ui_.page()),
              static_cast<unsigned int>(ui_.cursor()),
              static_cast<unsigned int>(ui_.offset()),
+             static_cast<unsigned int>(ui_.browseCount()),
+             static_cast<unsigned int>(ui_.queueOffset()),
+             static_cast<unsigned int>(ui_.settingsIndex()),
              static_cast<unsigned int>(player_.trackCount()));
 }
 
 void Mp3Controller::printQueuePreview(Print& out, uint8_t count, const char* source) const {
   const char* safeSource = (source != nullptr && source[0] != '\0') ? source : "preview";
   const uint16_t total = player_.trackCount();
+  const uint16_t queueOffset = ui_.queueOffset();
   if (count == 0U) {
     count = 5U;
   } else if (count > 12U) {
@@ -47,7 +51,8 @@ void Mp3Controller::printQueuePreview(Print& out, uint8_t count, const char* sou
   }
   uint8_t emitted = 0U;
   for (uint8_t i = 0U; i < count && i < total; ++i) {
-    const uint16_t nextOneBased = static_cast<uint16_t>(((current + i) % total) + 1U);
+    const uint16_t nextOneBased =
+        static_cast<uint16_t>(((current + queueOffset + i) % total) + 1U);
     const TrackEntry* entry = player_.trackEntryByNumber(nextOneBased);
     if (entry == nullptr) {
       continue;

--- a/hardware/firmware/esp32/src/screen/screen_frame.h
+++ b/hardware/firmware/esp32/src/screen/screen_frame.h
@@ -22,6 +22,10 @@ struct ScreenFrame {
   uint8_t startupStage = 0;
   uint8_t appStage = 0;
   uint8_t uiPage = 0;
+  uint16_t uiCursor = 0;
+  uint16_t uiOffset = 0;
+  uint16_t uiCount = 0;
+  uint16_t queueCount = 0;
   uint8_t repeatMode = 0;
   bool fxActive = false;
   uint8_t backendMode = 0;

--- a/hardware/firmware/esp32/src/screen/screen_link.cpp
+++ b/hardware/firmware/esp32/src/screen/screen_link.cpp
@@ -52,6 +52,10 @@ bool ScreenLink::update(const ScreenFrame& frame, bool forceKeyframe) {
                        frame.startupStage != lastStartupStage_ ||
                        frame.appStage != lastAppStage_ ||
                        frame.uiPage != lastUiPage_ ||
+                       frame.uiCursor != lastUiCursor_ ||
+                       frame.uiOffset != lastUiOffset_ ||
+                       frame.uiCount != lastUiCount_ ||
+                       frame.queueCount != lastQueueCount_ ||
                        frame.repeatMode != lastRepeatMode_ ||
                        frame.fxActive != lastFxActive_ ||
                        frame.backendMode != lastBackendMode_ ||
@@ -66,10 +70,10 @@ bool ScreenLink::update(const ScreenFrame& frame, bool forceKeyframe) {
     return false;
   }
 
-  char payload[232] = {};
+  char payload[280] = {};
   const int payloadLen = snprintf(payload,
                                   sizeof(payload),
-                                  "STAT,%u,%u,%u,%lu,%u,%u,%u,%u,%u,%u,%u,%d,%u,%u,%u,%u,%u,%u,%u,%lu,%u,%u,%u,%u,%u,%u",
+                                  "STAT,%u,%u,%u,%lu,%u,%u,%u,%u,%u,%u,%u,%d,%u,%u,%u,%u,%u,%u,%u,%lu,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u",
                                   frame.laDetected ? 1U : 0U,
                                   frame.mp3Playing ? 1U : 0U,
                                   frame.sdReady ? 1U : 0U,
@@ -95,7 +99,11 @@ bool ScreenLink::update(const ScreenFrame& frame, bool forceKeyframe) {
                                   frame.fxActive ? 1U : 0U,
                                   static_cast<unsigned int>(frame.backendMode),
                                   frame.scanBusy ? 1U : 0U,
-                                  static_cast<unsigned int>(frame.errorCode));
+                                  static_cast<unsigned int>(frame.errorCode),
+                                  static_cast<unsigned int>(frame.uiCursor),
+                                  static_cast<unsigned int>(frame.uiOffset),
+                                  static_cast<unsigned int>(frame.uiCount),
+                                  static_cast<unsigned int>(frame.queueCount));
   if (payloadLen <= 0) {
     return false;
   }
@@ -103,7 +111,7 @@ bool ScreenLink::update(const ScreenFrame& frame, bool forceKeyframe) {
   const size_t rawLen = strnlen(payload, sizeof(payload));
   const uint8_t crc = crc8(reinterpret_cast<const uint8_t*>(payload), rawLen);
 
-  char txFrame[256] = {};
+  char txFrame[304] = {};
   const int len = snprintf(txFrame, sizeof(txFrame), "%s,%02X\n", payload, static_cast<unsigned int>(crc));
   if (len <= 0) {
     return false;
@@ -136,6 +144,10 @@ bool ScreenLink::update(const ScreenFrame& frame, bool forceKeyframe) {
   lastStartupStage_ = frame.startupStage;
   lastAppStage_ = frame.appStage;
   lastUiPage_ = frame.uiPage;
+  lastUiCursor_ = frame.uiCursor;
+  lastUiOffset_ = frame.uiOffset;
+  lastUiCount_ = frame.uiCount;
+  lastQueueCount_ = frame.queueCount;
   lastRepeatMode_ = frame.repeatMode;
   lastFxActive_ = frame.fxActive;
   lastBackendMode_ = frame.backendMode;

--- a/hardware/firmware/esp32/src/screen/screen_link.h
+++ b/hardware/firmware/esp32/src/screen/screen_link.h
@@ -46,6 +46,10 @@ class ScreenLink {
   uint8_t lastStartupStage_ = 0;
   uint8_t lastAppStage_ = 0;
   uint8_t lastUiPage_ = 0;
+  uint16_t lastUiCursor_ = 0;
+  uint16_t lastUiOffset_ = 0;
+  uint16_t lastUiCount_ = 0;
+  uint16_t lastQueueCount_ = 0;
   uint8_t lastRepeatMode_ = 0;
   bool lastFxActive_ = false;
   uint8_t lastBackendMode_ = 0;

--- a/hardware/firmware/esp32/src/services/serial/serial_commands_mp3.cpp
+++ b/hardware/firmware/esp32/src/services/serial/serial_commands_mp3.cpp
@@ -49,11 +49,14 @@ void printUiStatus(Print& out, const Mp3SerialRuntimeContext& ctx, const char* s
     serialDispatchReply(out, "MP3_UI", SerialDispatchResult::kOutOfContext, "missing_context");
     return;
   }
-  out.printf("[MP3_UI] %s page=%s cursor=%u offset=%u tracks=%u\n",
+  out.printf("[MP3_UI] %s page=%s cursor=%u offset=%u browse=%u queue_off=%u set_idx=%u tracks=%u\n",
              source != nullptr ? source : "status",
              playerUiPageLabel(ctx.ui->page()),
              static_cast<unsigned int>(ctx.ui->cursor()),
              static_cast<unsigned int>(ctx.ui->offset()),
+             static_cast<unsigned int>(ctx.ui->browseCount()),
+             static_cast<unsigned int>(ctx.ui->queueOffset()),
+             static_cast<unsigned int>(ctx.ui->settingsIndex()),
              static_cast<unsigned int>(ctx.player->trackCount()));
 }
 

--- a/hardware/firmware/esp32/src/ui/player_ui_model.h
+++ b/hardware/firmware/esp32/src/ui/player_ui_model.h
@@ -26,6 +26,9 @@ struct PlayerUiSnapshot {
   PlayerUiPage page = PlayerUiPage::kNowPlaying;
   uint16_t cursor = 0;
   uint16_t offset = 0;
+  uint16_t browseCount = 0;
+  uint16_t queueOffset = 0;
+  uint8_t settingsIndex = 0;
   bool dirty = false;
 };
 
@@ -42,17 +45,24 @@ class PlayerUiModel {
   PlayerUiPage page() const;
   uint16_t cursor() const;
   uint16_t offset() const;
+  uint16_t browseCount() const;
+  uint16_t queueOffset() const;
+  uint8_t settingsIndex() const;
   bool consumeDirty();
 
  private:
   void clampBrowser();
-  void moveCursor(int16_t delta);
+  void moveBrowserCursor(int16_t delta);
+  void moveQueueOffset(int16_t delta);
+  void moveSettings(int8_t delta);
   void nextPage();
   void prevPage();
 
   PlayerUiPage page_ = PlayerUiPage::kNowPlaying;
   uint16_t browserCount_ = 0;
-  uint16_t cursor_ = 0;
-  uint16_t offset_ = 0;
+  uint16_t browserCursor_ = 0;
+  uint16_t browserOffset_ = 0;
+  uint16_t queueOffset_ = 0;
+  uint8_t settingsIndex_ = 0;
   bool dirty_ = true;
 };


### PR DESCRIPTION
## Scope
- UX MP3 etat interne renforcee sur ESP32 (pages NOW/BROWSE/QUEUE/SET)
- navigation clavier coherente selon page (browse cursor, queue offset, settings index + actions K1)
- `MP3_UI_STATUS` enrichi avec `browse`, `queue_off`, `set_idx`
- profil compile-time Story V2 pilotable par env (`USON_STORY_V2_DEFAULT`)
  - `esp32dev` => ON
  - `esp32_release` => OFF
- extension additive de trame `STAT` (uiCursor/uiOffset/uiCount/queueCount)
- parser ESP8266 backward-compatible + rendu MP3 page-aware base sur indicateurs structures

## Verification
- make story-validate
- make story-gen
- make qa-story-v2
- pio run -e esp32dev
- pio run -e esp32_release
- pio run -e esp8266_oled
- cd screen_esp8266_hw630 && pio run -e nodemcuv2

## Notes
- aucune regression sur commandes MP3 existantes
- fichier local reports/live_story_v2_smoke_20260213_181353.log reste hors commit
