### PR TITLE
MPRC-60/64: QA MP3 RC scripts + docs process

### DIFF
--- a/hardware/firmware/esp32/Makefile
+++ b/hardware/firmware/esp32/Makefile
@@ -7,7 +7,7 @@ SOAK_MINUTES ?= 20
 POLL_SECONDS ?= 15
 TRACE_LEVEL ?= INFO
 
-.PHONY: help build build-esp32 build-screen story-validate story-gen qa-story-v2 qa-story-v2-smoke qa-story-v2-smoke-fast qa-story-v2-rc upload-esp32 upload-screen uploadfs-esp32 erasefs-esp32 monitor-esp32 monitor-screen clean
+.PHONY: help build build-esp32 build-screen story-validate story-gen qa-story-v2 qa-story-v2-smoke qa-story-v2-smoke-fast qa-story-v2-rc qa-mp3-rc-smoke upload-esp32 upload-screen uploadfs-esp32 erasefs-esp32 monitor-esp32 monitor-screen clean
 
 help:
 	@echo "Targets:"
@@ -23,6 +23,7 @@ help:
 	@echo "  make qa-story-v2-smoke      # Story V2 live smoke (flash + serial commands)"
 	@echo "  make qa-story-v2-smoke-fast # Story V2 smoke without flashing"
 	@echo "  make qa-story-v2-rc         # Story V2 release-candidate matrix + soak"
+	@echo "  make qa-mp3-rc-smoke        # MP3 RC static smoke (build matrix + command checklist)"
 	@echo "  make upload-screen    # Flash ESP8266 (optional SCREEN_PORT=/dev/ttyUSB1)"
 	@echo "  make monitor-esp32    # Serial monitor ESP32 (optional ESP32_PORT=...)"
 	@echo "  make monitor-screen   # Serial monitor ESP8266 (optional SCREEN_PORT=...)"
@@ -47,6 +48,9 @@ qa-story-v2-smoke-fast:
 
 qa-story-v2-rc:
 	bash tools/qa/story_v2_rc_matrix.sh --esp32-port "$(ESP32_PORT)" --soak-minutes "$(SOAK_MINUTES)" --poll-seconds "$(POLL_SECONDS)" --trace-level "$(TRACE_LEVEL)"
+
+qa-mp3-rc-smoke:
+	bash tools/qa/mp3_rc_smoke.sh
 
 build-esp32:
 	$(PIO) run -e $(ESP32_ENV)

--- a/hardware/firmware/esp32/README.md
+++ b/hardware/firmware/esp32/README.md
@@ -178,7 +178,8 @@ Workflow auteur STORY V2:
 - `make qa-story-v2-smoke` (debut sprint, flash + smoke serie)
 - `make qa-story-v2-smoke-fast` (sans flash)
 - checklist review sprint: `tools/qa/story_v2_review_checklist.md`
-- `pio run -e esp32dev`
+- `pio run -e esp32dev` (profil dev, Story V2 ON)
+- `pio run -e esp32_release` (profil release, Story V2 OFF)
 
 Un nouveau scenario est ajoute via `story_specs/scenarios/*.yaml`, puis generation C++ dans `src/story/generated/*`.
 
@@ -214,11 +215,12 @@ Selection serie:
 ### Mode lecteur (SD detectee)
 
 - `K1` : play/pause
-- `K2` : piste precedente
-- `K3` : piste suivante
+- `K2` : piste precedente (page NOW) / navigation (pages BROWSE|QUEUE|SET)
+- `K3` : piste suivante (page NOW) / navigation (pages BROWSE|QUEUE|SET)
 - `K4` : volume -
 - `K5` : volume +
-- `K6` : repeat `ALL/ONE`
+- `K6` : changer de page UI (`NOW -> BROWSE -> QUEUE -> SET`)
+- En page `SET`, `K1` applique l'action selectionnee (`REPEAT`, `BACKEND`, `SCAN`)
 
 Le firmware bascule automatiquement selon la SD:
 - SD presente + pistes audio supportees: `MODE LECTEUR U-SON`
@@ -259,7 +261,9 @@ Depuis la racine de ce dossier (`hardware/firmware/esp32`):
 
 1. ESP32 principal:
    - `pio run -e esp32dev`
+   - `pio run -e esp32_release`
    - `pio run -e esp32dev -t upload --upload-port /dev/ttyUSB0`
+   - `pio run -e esp32_release -t upload --upload-port /dev/ttyUSB0`
    - `pio run -e esp32dev -t uploadfs --upload-port /dev/ttyUSB0`
    - `pio device monitor -e esp32dev --port /dev/ttyUSB0`
 2. ESP8266 OLED:
@@ -288,6 +292,8 @@ Astuce detection ports:
 - Runbook semi-auto Story V2: `tools/qa/live_story_v2_runbook.md`
 - Smoke debut sprint: `tools/qa/live_story_v2_smoke.sh`
 - Runbook release candidate: `tools/qa/live_story_v2_rc_runbook.md`
+- Smoke RC MP3: `tools/qa/mp3_rc_smoke.sh`
+- Runbook RC MP3: `tools/qa/mp3_rc_runbook.md`
 - Handbook release/rollback: `RELEASE_STORY_V2.md`
 
 ### CI / Review policy
@@ -299,7 +305,7 @@ Astuce detection ports:
   - `make story-validate`
   - `make story-gen`
   - `bash tools/qa/story_v2_ci.sh` (mode strict/idempotence)
-  - builds firmware `esp32dev`, `esp8266_oled`, `screen:nodemcuv2`
+  - builds firmware `esp32dev`, `esp32_release`, `esp8266_oled`, `screen:nodemcuv2`
 
 ## Lecteur audio evolue
 
@@ -320,8 +326,11 @@ Commandes MP3 utiles:
 - `MP3_SCAN START` : scan incremental (index prioritaire)
 - `MP3_SCAN REBUILD` : rebuild force sans index
 - `MP3_SCAN CANCEL` : annule un scan en cours
-- `MP3_SCAN_PROGRESS` : progression scan live (depth/stack/folders/files/tracks/limit)
+- `MP3_SCAN_PROGRESS` : progression scan live (state/pending/reason/depth/files/tracks/ticks/budget)
 - `MP3_BACKEND_STATUS` : compteurs runtime backend (attempts/fail/retry/fallback)
+- `MP3_UI_STATUS` : etat UI courant (`page/cursor/offset/browse/queue_off/set_idx`)
+- `MP3_QUEUE_PREVIEW [n]` : projection des prochaines pistes
+- `MP3_CAPS` : capacites codec/backend exposees au runtime
 
 Sons internes:
 

--- a/hardware/firmware/esp32/TESTING.md
+++ b/hardware/firmware/esp32/TESTING.md
@@ -30,6 +30,8 @@ Runbook live semi-automatique disponible:
 - `tools/qa/live_story_v2_runbook.md`
 - `tools/qa/live_story_v2_smoke.sh` (smoke debut sprint)
 - `tools/qa/live_story_v2_rc_runbook.md` (release candidate)
+- `tools/qa/mp3_rc_smoke.sh` (smoke RC MP3)
+- `tools/qa/mp3_rc_runbook.md` (runbook RC MP3)
 
 ## 0) Tooling STORY V2 (hors carte)
 
@@ -39,6 +41,7 @@ Runbook live semi-automatique disponible:
    - `make story-gen`
 3. Verifier idempotence + build matrix:
    - `make qa-story-v2`
+   - `pio run -e esp32_release`
 4. Attendu:
    - aucun diff apres generation repetee
    - hash spec visible dans `src/story/generated/*.h` et `src/story/generated/*.cpp`
@@ -303,9 +306,24 @@ Rollback (si anomalie en live):
    - `state=DONE`
    - `tracks>0` si des fichiers supportes sont presents
 5. Envoyer `MP3_SCAN_PROGRESS`:
-   - verifier `depth/stack/folders/files/tracks`
+   - verifier `state/pending/reason/depth/stack/folders/files/tracks/ticks/budget`
 6. Envoyer `MP3_BACKEND_STATUS`:
    - verifier compteurs `attempts/fail/retries/fallback`
+
+## 7b) UI MP3 NOW/BROWSE/QUEUE/SET
+
+1. Envoyer `MP3_UI_STATUS`:
+   - verifier `page`, `cursor`, `offset`, `browse`, `queue_off`, `set_idx`
+2. Envoyer successivement:
+   - `MP3_UI PAGE NOW`
+   - `MP3_UI PAGE BROWSE`
+   - `MP3_UI PAGE QUEUE`
+   - `MP3_UI PAGE SET`
+3. Envoyer `MP3_QUEUE_PREVIEW 5` et verifier la cohérence avec `queue_off`.
+4. En mode MP3, verifier les touches:
+   - `K6` change de page
+   - `K2/K3` naviguent en BROWSE/QUEUE/SET
+   - `K1` applique l'action settings en page `SET` (`REPEAT`, `BACKEND`, `SCAN`)
 
 ## 8) Diagnostics runtime/screen (serie)
 

--- a/hardware/firmware/esp32/screen_esp8266_hw630/README.md
+++ b/hardware/firmware/esp32/screen_esp8266_hw630/README.md
@@ -30,15 +30,16 @@ Ce decoupage garde la compatibilite protocole tout en permettant d'ajouter de no
 
 Trame texte envoyee par l'ESP32 (format etendu v2):
 
-`STAT,<la>,<mp3>,<sd>,<uptime_ms>,<key>,<mode_mp3>,<track>,<track_count>,<volume_pct>,<u_lock>,<u_son_functional>,<tuning_offset>,<tuning_confidence>,<u_lock_listening>,<mic_level_pct>,<mic_scope>,<unlock_hold_pct>,<startup_stage>,<app_stage>,<seq>,<ui_page>,<repeat_mode>,<fx_active>,<backend_mode>,<scan_busy>,<error_code>,<crc8_hex>\n`
+`STAT,<la>,<mp3>,<sd>,<uptime_ms>,<key>,<mode_mp3>,<track>,<track_count>,<volume_pct>,<u_lock>,<u_son_functional>,<tuning_offset>,<tuning_confidence>,<u_lock_listening>,<mic_level_pct>,<mic_scope>,<unlock_hold_pct>,<startup_stage>,<app_stage>,<seq>,<ui_page>,<repeat_mode>,<fx_active>,<backend_mode>,<scan_busy>,<error_code>,<ui_cursor>,<ui_offset>,<ui_count>,<queue_count>,<crc8_hex>\n`
 
 Exemple:
 
-`STAT,1,0,0,12345,2,0,0,0,0,1,0,-2,68,1,42,1,57,1,0,77,1,0,0,1,0,0,5A`
+`STAT,1,0,0,12345,2,0,0,0,0,1,0,-2,68,1,42,1,57,1,0,77,1,0,0,1,0,0,2,1,34,5,5A`
 
 Compatibilite:
 - le parser ecran accepte encore les trames `STAT` sans CRC (format legacy).
 - si CRC present, la trame est validee et rejetee si checksum invalide.
+- les champs UI MP3 (`ui_cursor/ui_offset/ui_count/queue_count`) sont optionnels et parses seulement s'ils sont presents.
 
 ## Cablage
 

--- a/hardware/firmware/esp32/tools/qa/mp3_rc_runbook.md
+++ b/hardware/firmware/esp32/tools/qa/mp3_rc_runbook.md
@@ -1,0 +1,56 @@
+# MP3 RC Runbook
+
+## 1) Preflight
+
+1. `pio device list`
+2. `tools/qa/mp3_rc_smoke.sh`
+
+## 2) Flash
+
+1. ESP32:
+- `make upload-esp32 ESP32_PORT=<PORT_ESP32>`
+- `make uploadfs-esp32 ESP32_PORT=<PORT_ESP32>`
+
+2. ESP8266 screen:
+- `make upload-screen SCREEN_PORT=<PORT_ESP8266>`
+
+## 3) Smoke runtime (ESP32 serial)
+
+1. `MP3_STATUS`
+2. `MP3_UI_STATUS`
+3. `MP3_SCAN START`
+4. `MP3_SCAN_PROGRESS`
+5. `MP3_UI PAGE NOW`
+6. `MP3_UI PAGE BROWSE`
+7. `MP3_UI PAGE QUEUE`
+8. `MP3_UI PAGE SET`
+9. `MP3_QUEUE_PREVIEW 5`
+10. `MP3_BACKEND STATUS`
+11. `MP3_BACKEND_STATUS`
+12. `MP3_CAPS`
+
+Expected:
+- responses use canonical status (`OK/BAD_ARGS/OUT_OF_CONTEXT/NOT_FOUND/BUSY/UNKNOWN`)
+- no freeze while scan is active
+- page state (`NOW/BROWSE/QUEUE/SET`) visible in `MP3_UI_STATUS`
+
+## 4) Keyboard parity
+
+1. Enter MP3 mode (SD with tracks)
+2. Validate keys:
+- `K1`: play/pause or settings action
+- `K2/K3`: prev/next in NOW, cursor/offset in BROWSE/QUEUE/SET
+- `K4/K5`: volume down/up
+- `K6`: page cycle
+
+## 5) Screen recovery
+
+1. Reset ESP8266 only
+2. Validate screen resumes state within ~2s
+3. Reset ESP32 only
+4. Validate handshake and rendering recovery
+
+## 6) Result
+
+- PASS if all steps are green
+- Otherwise list anomalies as `Critique`, `Majeure`, `Mineure`

--- a/hardware/firmware/esp32/tools/qa/mp3_rc_smoke.sh
+++ b/hardware/firmware/esp32/tools/qa/mp3_rc_smoke.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[mp3-rc-smoke] validate story specs"
+make story-validate
+
+echo "[mp3-rc-smoke] generate story sources"
+make story-gen
+
+echo "[mp3-rc-smoke] build esp32dev"
+pio run -e esp32dev
+
+echo "[mp3-rc-smoke] build esp32_release"
+pio run -e esp32_release
+
+echo "[mp3-rc-smoke] build esp8266_oled"
+pio run -e esp8266_oled
+
+echo "[mp3-rc-smoke] build screen nodemcuv2"
+(
+  cd screen_esp8266_hw630
+  pio run -e nodemcuv2
+)
+
+echo "[mp3-rc-smoke] static checks OK"
+echo "[mp3-rc-smoke] next live serial commands:"
+echo "  MP3_STATUS"
+echo "  MP3_UI_STATUS"
+echo "  MP3_SCAN START"
+echo "  MP3_SCAN_PROGRESS"
+echo "  MP3_QUEUE_PREVIEW 5"
+echo "  MP3_BACKEND_STATUS"
+echo "  MP3_CAPS"

--- a/hardware/firmware/esp32/tools/qa/mp3_review_checklist.md
+++ b/hardware/firmware/esp32/tools/qa/mp3_review_checklist.md
@@ -1,0 +1,33 @@
+# MP3 RC Review Checklist
+
+## Scope
+
+- [ ] MPRC-10/11: serial MP3 extraction + controller wiring
+- [ ] MPRC-20/21: scan runtime non-bloquant + progression enrichie
+- [ ] MPRC-30/31: UX MP3 NOW/BROWSE/QUEUE/SET + parite clavier/serie
+- [ ] MPRC-40/42: trame ecran MP3 UI et parser ESP8266 backward-compatible
+- [ ] Build profile: `esp32dev` ON story V2 / `esp32_release` OFF story V2
+
+## Canonical commands
+
+- [ ] `MP3_STATUS`
+- [ ] `MP3_UI_STATUS`
+- [ ] `MP3_QUEUE_PREVIEW [n]`
+- [ ] `MP3_CAPS`
+- [ ] `MP3_SCAN START|STATUS|CANCEL|REBUILD`
+- [ ] `MP3_SCAN_PROGRESS`
+- [ ] `MP3_BACKEND STATUS|SET <AUTO|AUDIO_TOOLS|LEGACY>`
+- [ ] `MP3_BACKEND_STATUS`
+
+## Runtime expectations
+
+- [ ] no blocking transition during scan
+- [ ] command latency acceptable under scan load
+- [ ] keyboard remains responsive during scan/audio
+- [ ] screen remains stable and recovers after reset/relink
+
+## Evidence
+
+- [ ] `tools/qa/mp3_rc_smoke.sh` output attached
+- [ ] live USB runbook executed (`tools/qa/mp3_rc_runbook.md`)
+- [ ] anomalies classified (Critique/Majeure/Mineure)


### PR DESCRIPTION
## Scope
- ajoute les artefacts QA MP3 RC:
  - `tools/qa/mp3_rc_smoke.sh`
  - `tools/qa/mp3_rc_runbook.md`
  - `tools/qa/mp3_review_checklist.md`
- ajoute cible make `qa-mp3-rc-smoke`
- met a jour la doc runtime:
  - profil `esp32_release` (Story V2 OFF)
  - commandes MP3 UI (`MP3_UI_STATUS`, `MP3_QUEUE_PREVIEW`, `MP3_CAPS`)
  - trame `STAT` etendue avec champs UI MP3

## Verification
- bash -n tools/qa/mp3_rc_smoke.sh
- make -n qa-mp3-rc-smoke
