### PR TITLE
MP3 RC: consolider Mp3Controller et simplifier l'orchestrateur

### DIFF
--- a/hardware/firmware/esp32/src/controllers/mp3/mp3_controller.h
+++ b/hardware/firmware/esp32/src/controllers/mp3/mp3_controller.h
@@ -12,7 +12,13 @@ class Mp3Controller {
   void update(uint32_t nowMs, bool allowPlayback);
   void refreshStorage();
   void applyUiAction(const UiAction& action);
+  const char* browsePath() const;
+  void setBrowsePath(const char* path);
   void printUiStatus(Print& out, const char* source) const;
+  void printScanStatus(Print& out, const char* source) const;
+  void printScanProgress(Print& out, const char* source) const;
+  void printBackendStatus(Print& out, const char* source) const;
+  void printBrowseList(Print& out, const char* source, const char* path, uint16_t offset, uint16_t limit) const;
   void printQueuePreview(Print& out, uint8_t count, const char* source) const;
   void printCapabilities(Print& out, const char* source) const;
 
@@ -24,4 +30,5 @@ class Mp3Controller {
  private:
   Mp3Player& player_;
   PlayerUiModel& ui_;
+  String browsePath_ = "/";
 };

--- a/hardware/firmware/esp32/src/services/serial/serial_commands_mp3.cpp
+++ b/hardware/firmware/esp32/src/services/serial/serial_commands_mp3.cpp
@@ -45,6 +45,10 @@ bool allowPlayback(const Mp3SerialRuntimeContext& ctx) {
 }
 
 void printUiStatus(Print& out, const Mp3SerialRuntimeContext& ctx, const char* source) {
+  if (ctx.printUiStatus != nullptr) {
+    ctx.printUiStatus(source != nullptr ? source : "status");
+    return;
+  }
   if (ctx.ui == nullptr || ctx.player == nullptr) {
     serialDispatchReply(out, "MP3_UI", SerialDispatchResult::kOutOfContext, "missing_context");
     return;

--- a/hardware/firmware/esp32/src/services/serial/serial_commands_mp3.h
+++ b/hardware/firmware/esp32/src/services/serial/serial_commands_mp3.h
@@ -21,6 +21,7 @@ struct Mp3SerialRuntimeContext {
   const char* (*currentBrowsePath)() = nullptr;
   void (*setBrowsePath)(const char* path) = nullptr;
   void (*printHelp)() = nullptr;
+  void (*printUiStatus)(const char* source) = nullptr;
   void (*printStatus)(const char* source) = nullptr;
   void (*printScanStatus)(const char* source) = nullptr;
   void (*printScanProgress)(const char* source) = nullptr;


### PR DESCRIPTION
## Scope
Lot RC MP3 V1 (MPRC-10/11) de consolidation du controleur MP3.

## Changements
- centralise `browse path` dans `Mp3Controller` (suppression de l'etat global correspondant dans l'orchestrateur)
- deplace les impressions MP3 scan/backend/browse dans `Mp3Controller`
- ajoute un hook `printUiStatus` dans `Mp3SerialRuntimeContext` pour router l'UI via le controleur
- simplifie les wrappers MP3 dans `app_orchestrator`

## Validation
- `pio run -e esp32dev`
- `pio run -e esp8266_oled`
- `cd screen_esp8266_hw630 && pio run -e nodemcuv2`

## Notes
- aucun fichier `reports/*.log` inclus dans ce commit
- comportement fonctionnel conserve (refactor structurel)
