### PR TITLE
MPRC-V2 PR-1: backend caps + fallback diagnostics + scan hardening

### DIFF
--- a/hardware/firmware/esp32/src/audio/catalog/track_catalog.cpp
+++ b/hardware/firmware/esp32/src/audio/catalog/track_catalog.cpp
@@ -38,7 +38,8 @@ bool readBounded(fs::File& file, uint8_t* out, size_t len, uint32_t timeoutMs) {
       if (static_cast<uint32_t>(millis() - startMs) >= timeoutMs) {
         break;
       }
-      delay(1);
+      // Keep metadata probing cooperative without forcing a full 1ms stall.
+      delay(0);
       continue;
     }
     out[pos++] = static_cast<uint8_t>(v);

--- a/hardware/firmware/esp32/src/audio/mp3_player.h
+++ b/hardware/firmware/esp32/src/audio/mp3_player.h
@@ -12,15 +12,6 @@
 class AudioFileSourceFS;
 class AudioGenerator;
 
-enum class AudioCodec : uint8_t {
-  kUnknown = 0,
-  kMp3,
-  kWav,
-  kAac,
-  kFlac,
-  kOpus,
-};
-
 enum class RepeatMode : uint8_t {
   kAll = 0,
   kOne = 1,
@@ -53,6 +44,15 @@ struct Mp3BackendRuntimeStats {
   uint32_t fallbackCount = 0U;
   uint32_t legacyStarts = 0U;
   uint32_t audioToolsStarts = 0U;
+  uint32_t legacyAttempts = 0U;
+  uint32_t legacySuccess = 0U;
+  uint32_t legacyFailures = 0U;
+  uint32_t legacyRetries = 0U;
+  uint32_t audioToolsAttempts = 0U;
+  uint32_t audioToolsSuccess = 0U;
+  uint32_t audioToolsFailures = 0U;
+  uint32_t audioToolsRetries = 0U;
+  char lastFallbackReason[32] = "NONE";
 };
 
 class Mp3Player {
@@ -106,6 +106,10 @@ class Mp3Player {
   const char* backendModeLabel() const;
   const char* activeBackendLabel() const;
   const char* lastBackendError() const;
+  const char* lastFallbackReason() const;
+  PlayerBackendCapabilities audioToolsCapabilities() const;
+  PlayerBackendCapabilities legacyCapabilities() const;
+  bool backendSupportsCodec(PlayerBackendId backend, AudioCodec codec) const;
 
   bool selectTrackByIndex(uint16_t index, bool restart = true);
   bool selectTrackByPath(const char* path, bool restart = true);

--- a/hardware/firmware/esp32/src/audio/player/audio_tools_backend.cpp
+++ b/hardware/firmware/esp32/src/audio/player/audio_tools_backend.cpp
@@ -36,6 +36,25 @@ bool endsWithIgnoreCase(const char* value, const char* suffix) {
   return true;
 }
 
+AudioCodec codecFromPath(const char* path) {
+  if (endsWithIgnoreCase(path, ".mp3")) {
+    return AudioCodec::kMp3;
+  }
+  if (endsWithIgnoreCase(path, ".wav")) {
+    return AudioCodec::kWav;
+  }
+  if (endsWithIgnoreCase(path, ".aac") || endsWithIgnoreCase(path, ".m4a")) {
+    return AudioCodec::kAac;
+  }
+  if (endsWithIgnoreCase(path, ".flac")) {
+    return AudioCodec::kFlac;
+  }
+  if (endsWithIgnoreCase(path, ".opus") || endsWithIgnoreCase(path, ".ogg")) {
+    return AudioCodec::kOpus;
+  }
+  return AudioCodec::kUnknown;
+}
+
 }  // namespace
 
 AudioToolsBackend::AudioToolsBackend(uint8_t i2sBclk,
@@ -52,11 +71,12 @@ bool AudioToolsBackend::start(const char* path, float gain) {
   setGain(gain);
 
   if (path == nullptr || path[0] == '\0') {
-    setLastError("BAD_PATH");
+    setLastError(PlayerBackendError::kBadPath);
     return false;
   }
-  if (!canHandlePath(path)) {
-    setLastError("UNSUPPORTED");
+  const AudioCodec codec = codecForPath(path);
+  if (!supportsCodec(codec)) {
+    setLastError(PlayerBackendError::kUnsupportedCodec);
     return false;
   }
   if (!setupI2s()) {
@@ -67,12 +87,12 @@ bool AudioToolsBackend::start(const char* path, float gain) {
   *file = SD_MMC.open(path, FILE_READ);
   if (!(*file) || file->isDirectory()) {
     delete file;
-    setLastError("OPEN_FAIL");
+    setLastError(PlayerBackendError::kOpenFail);
     return false;
   }
 
   file_ = file;
-  if (!setupDecoderForPath(path)) {
+  if (!setupDecoderForCodec(codec)) {
     stop();
     return false;
   }
@@ -85,7 +105,8 @@ bool AudioToolsBackend::start(const char* path, float gain) {
   active_ = true;
   eof_ = false;
   idleLoops_ = 0U;
-  setLastError("OK");
+  activeCodec_ = codec;
+  setLastError(PlayerBackendError::kOk);
   return true;
 }
 
@@ -97,7 +118,7 @@ void AudioToolsBackend::update() {
   auto* copy = static_cast<StreamCopy*>(copier_);
   auto* file = static_cast<fs::File*>(file_);
   if (copy == nullptr || file == nullptr || !(*file)) {
-    setLastError("RUNTIME");
+    setLastError(PlayerBackendError::kRuntimeError);
     stop();
     return;
   }
@@ -122,6 +143,7 @@ void AudioToolsBackend::update() {
 void AudioToolsBackend::stop() {
   active_ = false;
   idleLoops_ = 0U;
+  activeCodec_ = AudioCodec::kUnknown;
 
   auto* copy = static_cast<StreamCopy*>(copier_);
   if (copy != nullptr) {
@@ -163,7 +185,40 @@ bool AudioToolsBackend::isActive() const {
 }
 
 bool AudioToolsBackend::canHandlePath(const char* path) const {
-  return endsWithIgnoreCase(path, ".wav");
+  return supportsCodec(codecForPath(path));
+}
+
+AudioCodec AudioToolsBackend::codecForPath(const char* path) const {
+  return codecFromPath(path);
+}
+
+bool AudioToolsBackend::supportsCodec(AudioCodec codec) const {
+  switch (codec) {
+    case AudioCodec::kWav:
+      return true;
+    case AudioCodec::kMp3:
+    case AudioCodec::kAac:
+    case AudioCodec::kFlac:
+    case AudioCodec::kOpus:
+    case AudioCodec::kUnknown:
+    default:
+      return false;
+  }
+}
+
+PlayerBackendCapabilities AudioToolsBackend::capabilities() const {
+  PlayerBackendCapabilities caps;
+  caps.mp3 = false;
+  caps.wav = true;
+  caps.aac = false;
+  caps.flac = false;
+  caps.opus = false;
+  caps.supportsOverlayFx = false;
+  return caps;
+}
+
+PlayerBackendError AudioToolsBackend::lastErrorCode() const {
+  return lastErrorCode_;
 }
 
 const char* AudioToolsBackend::lastError() const {
@@ -200,23 +255,30 @@ bool AudioToolsBackend::setupI2s() {
   cfg.bits_per_sample = 16;
 
   if (!i2s->begin(cfg)) {
-    setLastError("I2S_FAIL");
+    setLastError(PlayerBackendError::kI2sFail);
     return false;
   }
   return true;
 }
 
-bool AudioToolsBackend::setupDecoderForPath(const char* path) {
+bool AudioToolsBackend::setupDecoderForCodec(AudioCodec codec) {
   AudioDecoder* decoder = nullptr;
-  if (endsWithIgnoreCase(path, ".wav")) {
-    decoder = new WAVDecoder();
-  } else {
-    setLastError("UNSUPPORTED");
-    return false;
+  switch (codec) {
+    case AudioCodec::kWav:
+      decoder = new WAVDecoder();
+      break;
+    case AudioCodec::kMp3:
+    case AudioCodec::kAac:
+    case AudioCodec::kFlac:
+    case AudioCodec::kOpus:
+    case AudioCodec::kUnknown:
+    default:
+      setLastError(PlayerBackendError::kUnsupportedCodec);
+      return false;
   }
 
   if (decoder == nullptr) {
-    setLastError("OOM");
+    setLastError(PlayerBackendError::kDecoderAllocFail);
     return false;
   }
 
@@ -224,13 +286,13 @@ bool AudioToolsBackend::setupDecoderForPath(const char* path) {
   auto* encoded = new EncodedAudioStream(i2s, decoder);
   if (encoded == nullptr) {
     delete decoder;
-    setLastError("OOM");
+    setLastError(PlayerBackendError::kOutOfMemory);
     return false;
   }
   if (!encoded->begin()) {
     delete encoded;
     delete decoder;
-    setLastError("DEC_FAIL");
+    setLastError(PlayerBackendError::kDecoderInitFail);
     return false;
   }
 
@@ -239,10 +301,7 @@ bool AudioToolsBackend::setupDecoderForPath(const char* path) {
   return true;
 }
 
-void AudioToolsBackend::setLastError(const char* code) {
-  if (code == nullptr || code[0] == '\0') {
-    snprintf(lastError_, sizeof(lastError_), "%s", "UNKNOWN");
-    return;
-  }
-  snprintf(lastError_, sizeof(lastError_), "%s", code);
+void AudioToolsBackend::setLastError(PlayerBackendError code) {
+  lastErrorCode_ = code;
+  snprintf(lastError_, sizeof(lastError_), "%s", playerBackendErrorLabel(code));
 }

--- a/hardware/firmware/esp32/src/audio/player/audio_tools_backend.h
+++ b/hardware/firmware/esp32/src/audio/player/audio_tools_backend.h
@@ -2,6 +2,8 @@
 
 #include <Arduino.h>
 
+#include "player_backend.h"
+
 class AudioToolsBackend {
  public:
   AudioToolsBackend(uint8_t i2sBclk, uint8_t i2sLrc, uint8_t i2sDout, uint8_t i2sPort);
@@ -12,6 +14,10 @@ class AudioToolsBackend {
 
   bool isActive() const;
   bool canHandlePath(const char* path) const;
+  AudioCodec codecForPath(const char* path) const;
+  bool supportsCodec(AudioCodec codec) const;
+  PlayerBackendCapabilities capabilities() const;
+  PlayerBackendError lastErrorCode() const;
   const char* lastError() const;
 
   void setGain(float gain);
@@ -19,8 +25,8 @@ class AudioToolsBackend {
 
  private:
   bool setupI2s();
-  bool setupDecoderForPath(const char* path);
-  void setLastError(const char* code);
+  bool setupDecoderForCodec(AudioCodec codec);
+  void setLastError(PlayerBackendError code);
 
   uint8_t i2sBclk_;
   uint8_t i2sLrc_;
@@ -31,6 +37,8 @@ class AudioToolsBackend {
   bool active_ = false;
   bool eof_ = false;
   uint8_t idleLoops_ = 0U;
+  AudioCodec activeCodec_ = AudioCodec::kUnknown;
+  PlayerBackendError lastErrorCode_ = PlayerBackendError::kOk;
   char lastError_[24] = "OK";
 
   void* i2s_ = nullptr;

--- a/hardware/firmware/esp32/src/audio/player/player_backend.h
+++ b/hardware/firmware/esp32/src/audio/player/player_backend.h
@@ -2,6 +2,15 @@
 
 #include <Arduino.h>
 
+enum class AudioCodec : uint8_t {
+  kUnknown = 0,
+  kMp3,
+  kWav,
+  kAac,
+  kFlac,
+  kOpus,
+};
+
 enum class PlayerBackendMode : uint8_t {
   kAutoFallback = 0,
   kAudioToolsOnly = 1,
@@ -14,13 +23,55 @@ enum class PlayerBackendId : uint8_t {
   kLegacy = 2,
 };
 
+enum class PlayerBackendError : uint8_t {
+  kOk = 0,
+  kBadPath,
+  kUnsupportedCodec,
+  kOpenFail,
+  kDecoderAllocFail,
+  kDecoderInitFail,
+  kI2sFail,
+  kRuntimeError,
+  kOutOfMemory,
+  kUnknown,
+};
+
+struct PlayerBackendCapabilities {
+  bool mp3 = false;
+  bool wav = false;
+  bool aac = false;
+  bool flac = false;
+  bool opus = false;
+  bool supportsOverlayFx = true;
+};
+
 struct PlayerBackendStatus {
   PlayerBackendMode mode = PlayerBackendMode::kAutoFallback;
   PlayerBackendId active = PlayerBackendId::kNone;
   bool fallbackUsed = false;
   bool supportsOverlayFx = true;
+  PlayerBackendCapabilities capabilities;
+  PlayerBackendError lastErrorCode = PlayerBackendError::kOk;
   char lastError[24] = {};
 };
+
+inline const char* audioCodecLabel(AudioCodec codec) {
+  switch (codec) {
+    case AudioCodec::kMp3:
+      return "MP3";
+    case AudioCodec::kWav:
+      return "WAV";
+    case AudioCodec::kAac:
+      return "AAC";
+    case AudioCodec::kFlac:
+      return "FLAC";
+    case AudioCodec::kOpus:
+      return "OPUS";
+    case AudioCodec::kUnknown:
+    default:
+      return "UNKNOWN";
+  }
+}
 
 inline const char* playerBackendModeLabel(PlayerBackendMode mode) {
   switch (mode) {
@@ -43,5 +94,49 @@ inline const char* playerBackendIdLabel(PlayerBackendId id) {
     case PlayerBackendId::kNone:
     default:
       return "NONE";
+  }
+}
+
+inline const char* playerBackendErrorLabel(PlayerBackendError error) {
+  switch (error) {
+    case PlayerBackendError::kOk:
+      return "OK";
+    case PlayerBackendError::kBadPath:
+      return "BAD_PATH";
+    case PlayerBackendError::kUnsupportedCodec:
+      return "UNSUPPORTED_CODEC";
+    case PlayerBackendError::kOpenFail:
+      return "OPEN_FAIL";
+    case PlayerBackendError::kDecoderAllocFail:
+      return "DECODER_ALLOC_FAIL";
+    case PlayerBackendError::kDecoderInitFail:
+      return "DECODER_INIT_FAIL";
+    case PlayerBackendError::kI2sFail:
+      return "I2S_FAIL";
+    case PlayerBackendError::kRuntimeError:
+      return "RUNTIME_ERROR";
+    case PlayerBackendError::kOutOfMemory:
+      return "OOM";
+    case PlayerBackendError::kUnknown:
+    default:
+      return "UNKNOWN";
+  }
+}
+
+inline bool playerBackendSupportsCodec(const PlayerBackendCapabilities& caps, AudioCodec codec) {
+  switch (codec) {
+    case AudioCodec::kMp3:
+      return caps.mp3;
+    case AudioCodec::kWav:
+      return caps.wav;
+    case AudioCodec::kAac:
+      return caps.aac;
+    case AudioCodec::kFlac:
+      return caps.flac;
+    case AudioCodec::kOpus:
+      return caps.opus;
+    case AudioCodec::kUnknown:
+    default:
+      return false;
   }
 }


### PR DESCRIPTION
## Scope
- Backend contract enrichi (`player_backend`) avec codecs/capabilities/erreurs normalisees
- `AudioToolsBackend` expose capacites runtime et erreurs structurees
- `Mp3Player` expose fallback reason + compteurs detailles par backend
- `MP3_BACKEND_STATUS` et `MP3_CAPS` rendus dynamiques cote controleur
- Durcissement scan metadata (`delay(1)` -> `delay(0)` cooperatif)

## Validation
- `make story-validate`
- `make story-gen`
- `make qa-story-v2`
- `pio run -e esp32_release`

## Notes
- AudioTools reste limite a `WAV` sur cet environnement (capacites reportees dynamiquement), fallback legacy conserve la garantie multi-formats.
