### PR TITLE
feat(mp3): kit présentation client stack lecteur

### DIFF
--- a/hardware/firmware/esp32/Makefile
+++ b/hardware/firmware/esp32/Makefile
@@ -7,7 +7,7 @@ SOAK_MINUTES ?= 20
 POLL_SECONDS ?= 15
 TRACE_LEVEL ?= INFO
 
-.PHONY: help build build-esp32 build-screen story-validate story-gen qa-story-v2 qa-story-v2-smoke qa-story-v2-smoke-fast qa-story-v2-rc qa-mp3-rc-smoke upload-esp32 upload-screen uploadfs-esp32 erasefs-esp32 monitor-esp32 monitor-screen clean
+.PHONY: help build build-esp32 build-screen story-validate story-gen qa-story-v2 qa-story-v2-smoke qa-story-v2-smoke-fast qa-story-v2-rc qa-mp3-rc-smoke qa-mp3-client-demo upload-esp32 upload-screen uploadfs-esp32 erasefs-esp32 monitor-esp32 monitor-screen clean
 
 help:
 	@echo "Targets:"
@@ -24,6 +24,7 @@ help:
 	@echo "  make qa-story-v2-smoke-fast # Story V2 smoke without flashing"
 	@echo "  make qa-story-v2-rc         # Story V2 release-candidate matrix + soak"
 	@echo "  make qa-mp3-rc-smoke        # MP3 RC static smoke (build matrix + command checklist)"
+	@echo "  make qa-mp3-client-demo     # MP3 client presentation smoke + contract checks"
 	@echo "  make upload-screen    # Flash ESP8266 (optional SCREEN_PORT=/dev/ttyUSB1)"
 	@echo "  make monitor-esp32    # Serial monitor ESP32 (optional ESP32_PORT=...)"
 	@echo "  make monitor-screen   # Serial monitor ESP8266 (optional SCREEN_PORT=...)"
@@ -51,6 +52,9 @@ qa-story-v2-rc:
 
 qa-mp3-rc-smoke:
 	bash tools/qa/mp3_rc_smoke.sh
+
+qa-mp3-client-demo:
+	bash tools/qa/mp3_client_demo_smoke.sh
 
 build-esp32:
 	$(PIO) run -e $(ESP32_ENV)

--- a/hardware/firmware/esp32/README.md
+++ b/hardware/firmware/esp32/README.md
@@ -294,6 +294,9 @@ Astuce detection ports:
 - Runbook release candidate: `tools/qa/live_story_v2_rc_runbook.md`
 - Smoke RC MP3: `tools/qa/mp3_rc_smoke.sh`
 - Runbook RC MP3: `tools/qa/mp3_rc_runbook.md`
+- Smoke client MP3: `tools/qa/mp3_client_demo_smoke.sh`
+- Checklist live client MP3: `tools/qa/mp3_client_live_checklist.md`
+- Kit presentation client MP3: `docs/client/mp3/`
 - Handbook release/rollback: `RELEASE_STORY_V2.md`
 
 ### CI / Review policy
@@ -331,6 +334,18 @@ Commandes MP3 utiles:
 - `MP3_UI_STATUS` : etat UI courant (`page/cursor/offset/browse/queue_off/set_idx`)
 - `MP3_QUEUE_PREVIEW [n]` : projection des prochaines pistes
 - `MP3_CAPS` : capacites codec/backend exposees au runtime
+
+Kit presentation client MP3:
+
+- `docs/client/mp3/01_pitch_executif.md`
+- `docs/client/mp3/02_architecture_stack.md`
+- `docs/client/mp3/03_demo_live_script.md`
+- `docs/client/mp3/04_evidence_qa.md`
+- `docs/client/mp3/05_risques_et_mitigations.md`
+- `docs/client/mp3/06_qna_client.md`
+- `docs/client/mp3/07_decisions_next_steps.md`
+- `tools/qa/mp3_client_demo_smoke.sh`
+- `tools/qa/mp3_client_live_checklist.md`
 
 Sons internes:
 

--- a/hardware/firmware/esp32/TESTING.md
+++ b/hardware/firmware/esp32/TESTING.md
@@ -32,6 +32,9 @@ Runbook live semi-automatique disponible:
 - `tools/qa/live_story_v2_rc_runbook.md` (release candidate)
 - `tools/qa/mp3_rc_smoke.sh` (smoke RC MP3)
 - `tools/qa/mp3_rc_runbook.md` (runbook RC MP3)
+- `tools/qa/mp3_client_demo_smoke.sh` (smoke presentation client MP3)
+- `tools/qa/mp3_client_live_checklist.md` (checklist operateur live client MP3)
+- `docs/client/mp3/` (kit complet presentation client)
 
 ## 0) Tooling STORY V2 (hors carte)
 
@@ -347,3 +350,16 @@ Rollback (si anomalie en live):
    - reset ESP32 seul
    - coupure/reprise liaison UART ecran
 4. Consigner la decision flag default ON/OFF dans `RELEASE_STORY_V2.md`.
+
+## 10) Kit presentation client MP3 (ordre recommande)
+
+1. Smoke statique client:
+   - `make qa-mp3-client-demo`
+2. Lire le script de demonstration:
+   - `docs/client/mp3/03_demo_live_script.md`
+3. Lancer la demo live en suivant:
+   - `tools/qa/mp3_client_live_checklist.md`
+4. En cas de fallback:
+   - `docs/client/mp3/04_evidence_qa.md`
+   - `docs/client/mp3/05_risques_et_mitigations.md`
+   - `docs/client/mp3/06_qna_client.md`

--- a/hardware/firmware/esp32/docs/client/mp3/01_pitch_executif.md
+++ b/hardware/firmware/esp32/docs/client/mp3/01_pitch_executif.md
@@ -1,0 +1,47 @@
+# Pitch executif - Stack lecteur MP3 U-SON
+
+## Objectif client
+
+Le lecteur MP3 U-SON apporte une experience audio robuste sur ESP32/ESP8266:
+
+- lecture locale SD avec scan non bloquant
+- UX pilotable au clavier, en serie et a l'OLED
+- observabilite runtime pour diagnostiquer vite
+- strategie backend dual pour garantir la lecture multi-formats
+
+## Valeur metier
+
+1. Fiabilite terrain:
+- le systeme reste reactif pendant scan et transitions UI
+- le lien ecran est resilient (trame `STAT` avec `seq` + CRC)
+
+2. Productivite exploitation:
+- commandes serie canoniques pour debug rapide
+- scripts QA/runbook pour reproduire les tests en atelier ou sur site
+
+3. Evolutivite:
+- capacites backend exposees en runtime (`MP3_CAPS`)
+- etat backend detaille (`MP3_BACKEND_STATUS`) pour piloter les decisions futures
+
+## Ce que la demo prouve
+
+1. UX complete:
+- pages `NOW`, `BROWSE`, `QUEUE`, `SET`
+- feedback action en moins de 250 ms (cible)
+
+2. Robustesse runtime:
+- scan actif sans gel de la boucle principale
+- reprise ecran apres reset croise ESP32/ESP8266
+
+3. Transparence technique:
+- fallback backend explicite via `last_fallback_reason`
+- compteurs d'essais/succes/echecs/retry par backend
+
+## Positionnement livraison
+
+Ce lot est pret pour presentation client:
+
+- documents operateur et Q&A fournis
+- scripts smoke et checklist live fournis
+- matrice build + QA statique rejouable
+

--- a/hardware/firmware/esp32/docs/client/mp3/02_architecture_stack.md
+++ b/hardware/firmware/esp32/docs/client/mp3/02_architecture_stack.md
@@ -1,0 +1,91 @@
+# Architecture - Stack lecteur MP3 moderne
+
+## Vue d'ensemble
+
+Le lecteur MP3 est construit en couches non bloquantes:
+
+1. `serial_commands_mp3`:
+- point d'entree canonique des commandes `MP3_*`
+
+2. `Mp3Controller`:
+- expose status/UI/caps/backend pour serie et ecran
+- centralise l'etat utile a la presentation
+
+3. `Mp3Player`:
+- orchestration playback + scan incremental + persistance
+- selection backend et fallback deterministe
+
+4. Backends audio:
+- `AudioToolsBackend` (capacites runtime declarees)
+- backend legacy ESP8266Audio (garantie multi-formats)
+
+5. Ecran ESP8266:
+- affiche l'etat MP3 via trame `STAT`
+- parse backward-compatible + robustesse `seq`/CRC
+
+## Contrats publics figes
+
+## Commandes MP3
+
+- `MP3_STATUS`
+- `MP3_UI_STATUS`
+- `MP3_SCAN START|STATUS|CANCEL|REBUILD`
+- `MP3_SCAN_PROGRESS`
+- `MP3_BACKEND STATUS|SET <AUTO|AUDIO_TOOLS|LEGACY>`
+- `MP3_BACKEND_STATUS`
+- `MP3_QUEUE_PREVIEW [n]`
+- `MP3_CAPS`
+
+Reponses canoniques:
+
+- `OK`
+- `BAD_ARGS`
+- `OUT_OF_CONTEXT`
+- `NOT_FOUND`
+- `BUSY`
+- `UNKNOWN`
+
+## Format backend status
+
+`MP3_BACKEND_STATUS` expose:
+
+- mode backend et backend actif
+- erreur courante + `last_fallback_reason`
+- compteurs globaux (`attempts/success/fail/retries/fallback`)
+- compteurs par backend (`tools_*`, `legacy_*`)
+
+## Format caps runtime
+
+`MP3_CAPS` expose les capacites reelles:
+
+- matrice codec/backend pour `tools` et `legacy`
+- mode et backend actif
+
+## Donnees ecran MP3
+
+Trame `STAT` (additive, backward-compatible):
+
+- `ui_cursor`
+- `ui_offset`
+- `ui_count`
+- `queue_count`
+
+## Strategie fallback
+
+1. Mode `AUTO_FALLBACK`:
+- tentative backend tools
+- fallback legacy si codec non supporte ou erreur d'init
+
+2. Mode `AUDIO_TOOLS_ONLY`:
+- pas de fallback, retry suivant politique runtime
+
+3. Mode `LEGACY_ONLY`:
+- bypass tools, compatibilite maximale
+
+## Points de fiabilite
+
+1. Scan catalogue incremental (budget par tick)
+2. Aucune attente active critique dans la boucle MP3
+3. Observabilite serie exploitable sans debugger
+4. Recovery ecran/lien sans bloquer l'audio
+

--- a/hardware/firmware/esp32/docs/client/mp3/03_demo_live_script.md
+++ b/hardware/firmware/esp32/docs/client/mp3/03_demo_live_script.md
@@ -1,0 +1,84 @@
+# Script demo live client (12 minutes)
+
+## Preparation (avant audience)
+
+1. Lancer `tools/qa/mp3_client_demo_smoke.sh`
+2. Flasher ESP32 + ESP8266:
+- `make upload-esp32 ESP32_PORT=<PORT_ESP32>`
+- `make uploadfs-esp32 ESP32_PORT=<PORT_ESP32>`
+- `make upload-screen SCREEN_PORT=<PORT_ESP8266>`
+3. Ouvrir moniteur ESP32:
+- `make monitor-esp32 ESP32_PORT=<PORT_ESP32>`
+
+## Deroule minute par minute
+
+## 0:00 - 2:00 Contexte
+
+Message:
+- "On montre une stack MP3 moderne, pilotable en live et robuste en runtime."
+- "Le systeme reste reactif pendant scan et recovery ecran."
+
+## 2:00 - 5:00 Etat runtime
+
+Commandes:
+
+1. `MP3_STATUS`
+2. `MP3_UI_STATUS`
+3. `MP3_CAPS`
+4. `MP3_BACKEND_STATUS`
+
+Attendus:
+
+- reponses canoniques
+- capacites runtime explicites
+- compteurs backend visibles
+
+## 5:00 - 9:00 UX complete 4 pages
+
+Commandes:
+
+1. `MP3_UI PAGE NOW`
+2. `MP3_UI PAGE BROWSE`
+3. `MP3_UI PAGE QUEUE`
+4. `MP3_UI PAGE SET`
+5. `MP3_UI_STATUS`
+6. `MP3_QUEUE_PREVIEW 5`
+
+Attendus:
+
+- OLED synchronise avec la page active
+- `MP3_UI_STATUS` coherent avec ce qui est affiche
+
+## 9:00 - 11:00 Scan non bloquant + fallback
+
+Commandes:
+
+1. `MP3_SCAN START`
+2. `MP3_SCAN_PROGRESS` (repetee 2-3 fois)
+3. `MP3_BACKEND STATUS`
+4. `MP3_BACKEND_STATUS`
+
+Attendus:
+
+- progression scan visible
+- aucune perte de reactivite serie/clavier/ecran
+- fallback reason exploitable si bascule backend
+
+## 11:00 - 12:00 Robustesse ecran
+
+Action:
+
+1. reset ESP8266 seul
+2. verifier reprise affichage (< 2 s cible)
+3. `MP3_UI_STATUS` pour prouver continuite cote ESP32
+
+## Plan de secours (backup)
+
+Si incident live:
+
+1. basculer sur logs pre-captures locaux (`reports/`, non versionnes)
+2. montrer les sections:
+- `docs/client/mp3/04_evidence_qa.md`
+- `tools/qa/mp3_client_live_checklist.md`
+- `docs/client/mp3/05_risques_et_mitigations.md`
+

--- a/hardware/firmware/esp32/docs/client/mp3/04_evidence_qa.md
+++ b/hardware/firmware/esp32/docs/client/mp3/04_evidence_qa.md
@@ -1,0 +1,59 @@
+# Evidence QA - Presentation client MP3
+
+## Snapshot execution
+
+- Date run: `2026-02-13 23:13 CET`
+- Branche: `feature/MP3-client-demo-pack-v1`
+- Base: `codex/esp32-audio-mozzi-20260213`
+- Story spec hash: `4146e7c78895`
+
+## Build / tooling (statique)
+
+Resultats a maintenir a jour avant chaque presentation:
+
+- `make story-validate` -> PASS
+- `make story-gen` -> PASS
+- `make qa-story-v2` -> PASS
+- `pio run -e esp32dev` -> PASS
+- `pio run -e esp32_release` -> PASS
+- `pio run -e esp8266_oled` -> PASS
+- `cd screen_esp8266_hw630 && pio run -e nodemcuv2` -> PASS
+
+## Smoke MP3 client
+
+- `tools/qa/mp3_rc_smoke.sh` -> PASS
+- `tools/qa/mp3_client_demo_smoke.sh` -> PASS
+
+Preuve smoke (extraits):
+
+- `[mp3-rc-smoke] static checks OK`
+- `[mp3-client-demo] PASS`
+
+## Verifications serie attendues
+
+1. `MP3_STATUS` -> etat SD/pistes coherent
+2. `MP3_UI_STATUS` -> page/cursor/offset coherents
+3. `MP3_SCAN_PROGRESS` -> scan evolutif sans gel
+4. `MP3_BACKEND_STATUS` -> fallback + compteurs lisibles
+5. `MP3_CAPS` -> matrice runtime backend/codec
+6. `MP3_QUEUE_PREVIEW 5` -> preview stable
+
+## Verifications live (terrain)
+
+1. UX 4 pages NOW/BROWSE/QUEUE/SET
+2. scan actif + navigation sans blocage
+3. reset croise ESP32/ESP8266 et recovery ecran
+
+## Anomalies (a remplir en repetition)
+
+## Critique
+
+- aucune
+
+## Majeure
+
+- aucune
+
+## Mineure
+
+- warnings toolchain tiers (deprecation/elf2bin) sans impact runtime

--- a/hardware/firmware/esp32/docs/client/mp3/05_risques_et_mitigations.md
+++ b/hardware/firmware/esp32/docs/client/mp3/05_risques_et_mitigations.md
@@ -1,0 +1,61 @@
+# Risques et mitigations - Demo client MP3
+
+## R1 - Instabilite USB/ports
+
+Impact:
+
+- perte de temps de demo, reset incomplet, moniteur non connecte
+
+Mitigation:
+
+- preflight `pio device list`
+- checklist ports `tools/qa/mp3_client_live_checklist.md`
+- plan backup logs/video
+
+## R2 - Promesse codec non alignee runtime
+
+Impact:
+
+- incomprehension client sur la couverture reelle des backends
+
+Mitigation:
+
+- ne pas annoncer en dur
+- montrer `MP3_CAPS` en live comme source de verite
+- expliquer fallback legacy pour garantie multi-formats
+
+## R3 - Freeze percu pendant scan
+
+Impact:
+
+- perception de manque de robustesse
+
+Mitigation:
+
+- lancer `MP3_SCAN START`
+- prouver reactivite via navigation/page change + `MP3_SCAN_PROGRESS`
+- rappeler budget tick non bloquant
+
+## R4 - Reconnexion ecran lente ou erratique
+
+Impact:
+
+- demo interrompue, doute sur robustesse systeme
+
+Mitigation:
+
+- test reset croise en repetition
+- conserver commande `MP3_UI_STATUS` pour prouver continuite ESP32
+- fallback narration sur runbook + evidences
+
+## R5 - Divergence branches/PR
+
+Impact:
+
+- demo sur un code non traceable
+
+Mitigation:
+
+- sequence PR imposee (`#44` mergee, branche demo dediee)
+- commit/tag de presentation explicites
+

--- a/hardware/firmware/esp32/docs/client/mp3/06_qna_client.md
+++ b/hardware/firmware/esp32/docs/client/mp3/06_qna_client.md
@@ -1,0 +1,56 @@
+# Q&A client - Stack MP3
+
+## Q1 - Pourquoi deux backends audio ?
+
+Reponse:
+
+- pour combiner modernisation et garantie terrain
+- backend tools pour la trajectoire moderne
+- backend legacy pour la couverture multi-formats et la continite de service
+
+## Q2 - Comment vous prouvez que ca reste fluide ?
+
+Reponse:
+
+- scan incremental avec budget par tick
+- commandes serie repondent pendant scan
+- navigation UI et ecran restent reactifs
+
+## Q3 - Que se passe-t-il si un codec n'est pas supporte par le backend actif ?
+
+Reponse:
+
+- en `AUTO_FALLBACK`, bascule vers legacy
+- `MP3_BACKEND_STATUS` expose `last_fallback_reason` et les compteurs
+
+## Q4 - L'ecran peut se desynchroniser ?
+
+Reponse:
+
+- protocole `STAT` resilient avec `seq` + CRC
+- parser backward-compatible
+- reprise apres reset croise testee en runbook
+
+## Q5 - Quel est le risque principal en production ?
+
+Reponse:
+
+- variabilite materielle USB/SD/qualite fichiers
+- mitigee par scripts QA, checklist live et observabilite runtime
+
+## Q6 - Que faut-il pour ajouter des fonctions MP3 ensuite ?
+
+Reponse:
+
+- conserver le contrat canonique `MP3_*`
+- enrichir controller/UI sans casser les commandes existantes
+- ajouter evidence QA et smoke avant merge
+
+## Q7 - Quelle est la prochaine etape apres cette demo ?
+
+Reponse:
+
+- finaliser extraction complete logique MP3 hors orchestrateur
+- stabiliser UX OLED page-aware en condition chargee
+- industrialiser campagne live RC avec rapport automatique
+

--- a/hardware/firmware/esp32/docs/client/mp3/07_decisions_next_steps.md
+++ b/hardware/firmware/esp32/docs/client/mp3/07_decisions_next_steps.md
@@ -1,0 +1,43 @@
+# Decisions et next steps apres presentation client
+
+## Decisions figees pour cette presentation
+
+1. Scope client: MP3 uniquement
+2. Format: live + backup
+3. Reponses serie canoniques strictes
+4. `MP3_CAPS` dynamique runtime comme reference officielle
+5. Pas de `vTask` sur ce lot
+
+## Decisions a prendre apres demo
+
+1. Priorite roadmap:
+- extraction complete MP3 hors orchestrateur
+- optimisation rendu OLED MP3 en charge
+- extension observabilite backend
+
+2. Politique backend:
+- garder `AUTO_FALLBACK` par defaut
+- definir eventuelle ouverture progressive capabilities tools
+
+3. Process release:
+- cadence smoke live par sprint
+- synchro branches `codex -> main -> codex` imposee
+
+## Next steps techniques proposes
+
+1. PR MP3 V2.2:
+- extraction actions clavier/serie vers `Mp3Controller`
+- nettoyage final du wiring MP3 dans orchestrateur
+
+2. PR MP3 V2.3:
+- finalisation UI ESP8266 page-aware
+- stabilisation anti-flicker + rendu partiel
+
+3. PR MP3 V2.4:
+- extension status backend (reasons normalisees)
+- dashboard serie compact pour support terrain
+
+4. PR MP3 V2.5:
+- campagne RC live scriptable avec rapport genere
+- publication artefacts de repetition (sans logs sensibles)
+

--- a/hardware/firmware/esp32/screen_esp8266_hw630/README.md
+++ b/hardware/firmware/esp32/screen_esp8266_hw630/README.md
@@ -70,3 +70,11 @@ Sinon, depuis ce dossier:
 1. `pio run`
 2. `pio run -t upload`
 3. `pio device monitor`
+
+## Validation demo client MP3
+
+Pour une demonstration client orientee MP3:
+
+- smoke statique: `bash ../tools/qa/mp3_client_demo_smoke.sh`
+- checklist operateur live: `../tools/qa/mp3_client_live_checklist.md`
+- script de narration: `../docs/client/mp3/03_demo_live_script.md`

--- a/hardware/firmware/esp32/tools/qa/mp3_client_demo_smoke.sh
+++ b/hardware/firmware/esp32/tools/qa/mp3_client_demo_smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[mp3-client-demo] baseline smoke"
+bash tools/qa/mp3_rc_smoke.sh
+
+echo "[mp3-client-demo] verify MP3 command surface"
+rg -q "MP3_STATUS" src/services/serial/serial_commands_mp3.cpp
+rg -q "MP3_UI_STATUS" src/services/serial/serial_commands_mp3.cpp
+rg -q "MP3_SCAN_PROGRESS" src/services/serial/serial_commands_mp3.cpp
+rg -q "MP3_BACKEND_STATUS" src/services/serial/serial_commands_mp3.cpp
+rg -q "MP3_CAPS" src/services/serial/serial_commands_mp3.cpp
+rg -q "MP3_QUEUE_PREVIEW" src/services/serial/serial_commands_mp3.cpp
+
+echo "[mp3-client-demo] verify backend observability fields"
+rg -q "last_fallback_reason" src/controllers/mp3/mp3_controller.cpp
+rg -q "tools_attempt=" src/controllers/mp3/mp3_controller.cpp
+rg -q "legacy_attempt=" src/controllers/mp3/mp3_controller.cpp
+
+echo "[mp3-client-demo] verify OLED MP3 structured fields"
+rg -q "uiCursor" screen_esp8266_hw630/src/core/telemetry_state.h
+rg -q "uiOffset" screen_esp8266_hw630/src/core/telemetry_state.h
+rg -q "uiCount" screen_esp8266_hw630/src/core/telemetry_state.h
+rg -q "queueCount" screen_esp8266_hw630/src/core/telemetry_state.h
+
+echo "[mp3-client-demo] verify screen link robustness fields"
+rg -q "frameSeq" screen_esp8266_hw630/src/core/telemetry_state.h
+rg -q "crc" screen_esp8266_hw630/src/core/stat_parser.cpp
+
+echo "[mp3-client-demo] PASS"

--- a/hardware/firmware/esp32/tools/qa/mp3_client_live_checklist.md
+++ b/hardware/firmware/esp32/tools/qa/mp3_client_live_checklist.md
@@ -1,0 +1,58 @@
+# Checklist live client MP3 (operateur)
+
+## A. Preflight materiel
+
+- [ ] `pio device list` execute
+- [ ] port ESP32 identifie
+- [ ] port ESP8266 identifie
+- [ ] carte SD inseree (pistes de test chargees)
+- [ ] liaison UART ESP32->ESP8266 verifiee (`GPIO22 -> D6`, GND commun)
+
+## B. Flash
+
+- [ ] `make upload-esp32 ESP32_PORT=<PORT_ESP32>`
+- [ ] `make uploadfs-esp32 ESP32_PORT=<PORT_ESP32>`
+- [ ] `make upload-screen SCREEN_PORT=<PORT_ESP8266>`
+- [ ] moniteur ESP32 ouvert
+
+## C. Script commandes live (ordre fige)
+
+- [ ] `MP3_STATUS`
+- [ ] `MP3_UI_STATUS`
+- [ ] `MP3_SCAN START`
+- [ ] `MP3_SCAN_PROGRESS`
+- [ ] `MP3_UI PAGE NOW`
+- [ ] `MP3_UI PAGE BROWSE`
+- [ ] `MP3_UI PAGE QUEUE`
+- [ ] `MP3_UI PAGE SET`
+- [ ] `MP3_QUEUE_PREVIEW 5`
+- [ ] `MP3_BACKEND STATUS`
+- [ ] `MP3_BACKEND_STATUS`
+- [ ] `MP3_CAPS`
+
+## D. Validation immediate
+
+- [ ] reponses canoniques visibles
+- [ ] OLED affiche la page active
+- [ ] scan non bloquant perceptible
+- [ ] backend status lisible (fallback/counters)
+
+## E. Recovery rapide
+
+- [ ] reset ESP8266 seul -> reprise ecran < 2 s
+- [ ] reset ESP32 seul -> reprise sequence normale
+
+## F. Conditions fallback backup
+
+Declencher backup si au moins un critere est vrai:
+
+- [ ] port USB instable (> 1 deconnexion)
+- [ ] erreur critique non recuperable pendant la fenetre demo
+- [ ] temps restant demo < 3 minutes
+
+Actions fallback:
+
+1. Basculer sur `docs/client/mp3/04_evidence_qa.md`
+2. Montrer `docs/client/mp3/05_risques_et_mitigations.md`
+3. Poursuivre Q&A avec `docs/client/mp3/06_qna_client.md`
+

--- a/hardware/firmware/esp32/tools/qa/mp3_rc_runbook.md
+++ b/hardware/firmware/esp32/tools/qa/mp3_rc_runbook.md
@@ -33,6 +33,8 @@ Expected:
 - responses use canonical status (`OK/BAD_ARGS/OUT_OF_CONTEXT/NOT_FOUND/BUSY/UNKNOWN`)
 - no freeze while scan is active
 - page state (`NOW/BROWSE/QUEUE/SET`) visible in `MP3_UI_STATUS`
+- backend status exposes `last_fallback_reason` and per-backend counters
+- caps output reflects runtime capabilities per backend (no hardcoded promise)
 
 ## 4) Keyboard parity
 
@@ -54,3 +56,8 @@ Expected:
 
 - PASS if all steps are green
 - Otherwise list anomalies as `Critique`, `Majeure`, `Mineure`
+
+Presentation support:
+
+- `tools/qa/mp3_client_live_checklist.md`
+- `docs/client/mp3/03_demo_live_script.md`

--- a/hardware/firmware/esp32/tools/qa/mp3_review_checklist.md
+++ b/hardware/firmware/esp32/tools/qa/mp3_review_checklist.md
@@ -25,9 +25,13 @@
 - [ ] command latency acceptable under scan load
 - [ ] keyboard remains responsive during scan/audio
 - [ ] screen remains stable and recovers after reset/relink
+- [ ] `MP3_BACKEND_STATUS` inclut `last_fallback_reason` + compteurs `tools_*` / `legacy_*`
+- [ ] `MP3_CAPS` expose des capacites runtime dynamiques (pas de promesse hardcodee)
 
 ## Evidence
 
 - [ ] `tools/qa/mp3_rc_smoke.sh` output attached
+- [ ] `tools/qa/mp3_client_demo_smoke.sh` output attached
 - [ ] live USB runbook executed (`tools/qa/mp3_rc_runbook.md`)
+- [ ] checklist operateur client verifiee (`tools/qa/mp3_client_live_checklist.md`)
 - [ ] anomalies classified (Critique/Majeure/Mineure)


### PR DESCRIPTION
## Objectif
Livrer un kit complet de présentation client pour la stack lecteur MP3 (live + backup), sans changer les contrats runtime.

## Contenu
- ajout du dossier `docs/client/mp3/` (pitch, architecture, script live, evidence QA, risques, Q&A, next steps)
- ajout du smoke dédié `tools/qa/mp3_client_demo_smoke.sh`
- ajout de la checklist opérateur `tools/qa/mp3_client_live_checklist.md`
- intégration Makefile (`qa-mp3-client-demo`)
- mise à jour docs centrales (`README.md`, `TESTING.md`, `screen_esp8266_hw630/README.md`)
- MAJ runbook/checklist review MP3 RC

## Vérifications exécutées
- make story-validate
- make story-gen
- make qa-story-v2
- pio run -e esp32dev
- pio run -e esp32_release
- pio run -e esp8266_oled
- cd screen_esp8266_hw630 && pio run -e nodemcuv2
- tools/qa/mp3_rc_smoke.sh
- tools/qa/mp3_client_demo_smoke.sh

## Notes
- Scope strictement MP3/demo-client (pas de changement métier Story/FX).
- Logs bruts `reports/*` non versionnés par design.
