### PR TITLE
chore(firmware): remove conflict markers in mp3 files

### DIFF
--- a/hardware/firmware/esp32/src/audio/mp3_player.cpp
+++ b/hardware/firmware/esp32/src/audio/mp3_player.cpp
@@ -42,26 +42,11 @@ void setScanReason(Mp3ScanProgress* progress, const char* reason) {
   copyCStr(progress->reason, sizeof(progress->reason), reason);
 }
 
-<<<<<<< HEAD
 void setFallbackReason(Mp3BackendRuntimeStats* stats, const char* reason) {
   if (stats == nullptr) {
     return;
   }
   copyCStr(stats->lastFallbackReason, sizeof(stats->lastFallbackReason), reason);
-=======
-void setBackendReason(Mp3BackendRuntimeStats* stats, const char* reason) {
-  if (stats == nullptr) {
-    return;
-  }
-  copyCStr(stats->lastFailureReason, sizeof(stats->lastFailureReason), reason);
-}
-
-void setFallbackPath(Mp3BackendRuntimeStats* stats, const char* path) {
-  if (stats == nullptr) {
-    return;
-  }
-  copyCStr(stats->lastFallbackPath, sizeof(stats->lastFallbackPath), path);
->>>>>>> feature/MPRC-RC1-mp3-audio
 }
 
 bool isJsonSafeChar(char c) {
@@ -139,12 +124,7 @@ void Mp3Player::begin() {
   scanProgress_.tickEntryBudget = kScanTickEntryBudget;
   setScanReason(&scanProgress_, "IDLE");
   backendStats_ = Mp3BackendRuntimeStats();
-<<<<<<< HEAD
   setFallbackReason(&backendStats_, "NONE");
-=======
-  setBackendReason(&backendStats_, "OK");
-  setFallbackPath(&backendStats_, "NONE");
->>>>>>> feature/MPRC-RC1-mp3-audio
 }
 
 void Mp3Player::update(uint32_t nowMs, bool allowPlayback) {
@@ -974,24 +954,16 @@ bool Mp3Player::startLegacyTrack() {
   ++backendStats_.legacyAttempts;
   if (!sdReady_ || trackCount_ == 0U || currentTrack_ >= trackCount_) {
     ++backendStats_.startFailures;
-<<<<<<< HEAD
     ++backendStats_.legacyFailures;
     copyCStr(backendError_, sizeof(backendError_), "OUT_OF_CONTEXT");
-=======
-    setBackendReason(&backendStats_, "NO_TRACK");
->>>>>>> feature/MPRC-RC1-mp3-audio
     return false;
   }
 
   const TrackEntry* entry = catalog_.entry(currentTrack_);
   if (entry == nullptr || entry->path[0] == '\0') {
     ++backendStats_.startFailures;
-<<<<<<< HEAD
     ++backendStats_.legacyFailures;
     copyCStr(backendError_, sizeof(backendError_), "BAD_PATH");
-=======
-    setBackendReason(&backendStats_, "NO_ENTRY");
->>>>>>> feature/MPRC-RC1-mp3-audio
     return false;
   }
 
@@ -1003,12 +975,8 @@ bool Mp3Player::startLegacyTrack() {
     ++backendStats_.retriesScheduled;
     ++backendStats_.legacyRetries;
     ++backendStats_.startFailures;
-<<<<<<< HEAD
     ++backendStats_.legacyFailures;
     copyCStr(backendError_, sizeof(backendError_), "UNSUPPORTED_CODEC");
-=======
-    setBackendReason(&backendStats_, "UNSUPPORTED_CODEC");
->>>>>>> feature/MPRC-RC1-mp3-audio
     return false;
   }
 
@@ -1019,12 +987,8 @@ bool Mp3Player::startLegacyTrack() {
     ++backendStats_.retriesScheduled;
     ++backendStats_.legacyRetries;
     ++backendStats_.startFailures;
-<<<<<<< HEAD
     ++backendStats_.legacyFailures;
     copyCStr(backendError_, sizeof(backendError_), "OPEN_FAIL");
-=======
-    setBackendReason(&backendStats_, "MISSING_FILE");
->>>>>>> feature/MPRC-RC1-mp3-audio
     return false;
   }
 
@@ -1039,12 +1003,8 @@ bool Mp3Player::startLegacyTrack() {
     ++backendStats_.retriesScheduled;
     ++backendStats_.legacyRetries;
     ++backendStats_.startFailures;
-<<<<<<< HEAD
     ++backendStats_.legacyFailures;
     copyCStr(backendError_, sizeof(backendError_), "OOM");
-=======
-    setBackendReason(&backendStats_, "ALLOC_FAIL");
->>>>>>> feature/MPRC-RC1-mp3-audio
     return false;
   }
 
@@ -1060,12 +1020,8 @@ bool Mp3Player::startLegacyTrack() {
     ++backendStats_.retriesScheduled;
     ++backendStats_.legacyRetries;
     ++backendStats_.startFailures;
-<<<<<<< HEAD
     ++backendStats_.legacyFailures;
     copyCStr(backendError_, sizeof(backendError_), "DECODER_INIT_FAIL");
-=======
-    setBackendReason(&backendStats_, "DECODER_BEGIN_FAIL");
->>>>>>> feature/MPRC-RC1-mp3-audio
     return false;
   }
 
@@ -1073,11 +1029,7 @@ bool Mp3Player::startLegacyTrack() {
   copyCStr(backendError_, sizeof(backendError_), "OK");
   ++backendStats_.startSuccess;
   ++backendStats_.legacyStarts;
-<<<<<<< HEAD
   ++backendStats_.legacySuccess;
-=======
-  setBackendReason(&backendStats_, "OK");
->>>>>>> feature/MPRC-RC1-mp3-audio
   Serial.printf("[MP3] Playing %u/%u [%s|LEGACY]: %s\n",
                 static_cast<unsigned int>(currentTrack_ + 1U),
                 static_cast<unsigned int>(trackCount_),
@@ -1091,45 +1043,29 @@ bool Mp3Player::startAudioToolsTrack() {
   ++backendStats_.audioToolsAttempts;
   if (!sdReady_ || trackCount_ == 0U || currentTrack_ >= trackCount_) {
     ++backendStats_.startFailures;
-<<<<<<< HEAD
     ++backendStats_.audioToolsFailures;
     copyCStr(backendError_, sizeof(backendError_), "OUT_OF_CONTEXT");
-=======
-    setBackendReason(&backendStats_, "NO_TRACK");
->>>>>>> feature/MPRC-RC1-mp3-audio
     return false;
   }
   const TrackEntry* entry = catalog_.entry(currentTrack_);
   if (entry == nullptr || entry->path[0] == '\0') {
     ++backendStats_.startFailures;
-<<<<<<< HEAD
     ++backendStats_.audioToolsFailures;
     copyCStr(backendError_, sizeof(backendError_), "BAD_PATH");
-=======
-    setBackendReason(&backendStats_, "NO_ENTRY");
->>>>>>> feature/MPRC-RC1-mp3-audio
     return false;
   }
   const AudioCodec trackCodec = codecForPath(String(entry->path));
   if (!audioTools_.supportsCodec(trackCodec)) {
     copyCStr(backendError_, sizeof(backendError_), "UNSUPPORTED_CODEC");
     ++backendStats_.startFailures;
-<<<<<<< HEAD
     ++backendStats_.audioToolsFailures;
-=======
-    setBackendReason(&backendStats_, "AT_UNSUPPORTED");
->>>>>>> feature/MPRC-RC1-mp3-audio
     return false;
   }
 
   if (!audioTools_.start(entry->path, gain_)) {
     copyCStr(backendError_, sizeof(backendError_), audioTools_.lastError());
     ++backendStats_.startFailures;
-<<<<<<< HEAD
     ++backendStats_.audioToolsFailures;
-=======
-    setBackendReason(&backendStats_, audioTools_.lastError());
->>>>>>> feature/MPRC-RC1-mp3-audio
     return false;
   }
 
@@ -1138,11 +1074,7 @@ bool Mp3Player::startAudioToolsTrack() {
   copyCStr(backendError_, sizeof(backendError_), "OK");
   ++backendStats_.startSuccess;
   ++backendStats_.audioToolsStarts;
-<<<<<<< HEAD
   ++backendStats_.audioToolsSuccess;
-=======
-  setBackendReason(&backendStats_, "OK");
->>>>>>> feature/MPRC-RC1-mp3-audio
   Serial.printf("[MP3] Playing %u/%u [%s|AUDIO_TOOLS]: %s\n",
                 static_cast<unsigned int>(currentTrack_ + 1U),
                 static_cast<unsigned int>(trackCount_),
@@ -1159,11 +1091,7 @@ void Mp3Player::startCurrentTrack() {
   }
 
   fallbackUsed_ = false;
-<<<<<<< HEAD
   setFallbackReason(&backendStats_, "NONE");
-=======
-  setFallbackPath(&backendStats_, "NONE");
->>>>>>> feature/MPRC-RC1-mp3-audio
   bool started = false;
   bool attemptedLegacy = false;
   bool attemptedTools = false;
@@ -1174,16 +1102,9 @@ void Mp3Player::startCurrentTrack() {
     if (!started && backendMode_ == PlayerBackendMode::kAutoFallback) {
       fallbackUsed_ = true;
       ++backendStats_.fallbackCount;
-<<<<<<< HEAD
       setFallbackReason(&backendStats_, backendError_);
       attemptedLegacy = true;
-=======
-      setFallbackPath(&backendStats_, "AT->LEGACY");
->>>>>>> feature/MPRC-RC1-mp3-audio
       started = startLegacyTrack();
-      if (!started) {
-        setFallbackPath(&backendStats_, "AT->LEGACY_FAIL");
-      }
     }
   } else {
     attemptedLegacy = true;
@@ -1205,15 +1126,10 @@ void Mp3Player::startCurrentTrack() {
   if (!started) {
     nextRetryMs_ = millis() + 1000U;
     ++backendStats_.retriesScheduled;
-<<<<<<< HEAD
     if (attemptedLegacy) {
       ++backendStats_.legacyRetries;
     } else if (attemptedTools) {
       ++backendStats_.audioToolsRetries;
-=======
-    if (backendError_[0] == '\0') {
-      copyCStr(backendError_, sizeof(backendError_), "START_FAIL");
->>>>>>> feature/MPRC-RC1-mp3-audio
     }
     return;
   }

--- a/hardware/firmware/esp32/src/audio/mp3_player.h
+++ b/hardware/firmware/esp32/src/audio/mp3_player.h
@@ -44,7 +44,6 @@ struct Mp3BackendRuntimeStats {
   uint32_t fallbackCount = 0U;
   uint32_t legacyStarts = 0U;
   uint32_t audioToolsStarts = 0U;
-<<<<<<< HEAD
   uint32_t legacyAttempts = 0U;
   uint32_t legacySuccess = 0U;
   uint32_t legacyFailures = 0U;
@@ -54,10 +53,6 @@ struct Mp3BackendRuntimeStats {
   uint32_t audioToolsFailures = 0U;
   uint32_t audioToolsRetries = 0U;
   char lastFallbackReason[32] = "NONE";
-=======
-  char lastFailureReason[24] = "OK";
-  char lastFallbackPath[24] = "NONE";
->>>>>>> feature/MPRC-RC1-mp3-audio
 };
 
 class Mp3Player {

--- a/hardware/firmware/esp32/src/controllers/mp3/mp3_controller.cpp
+++ b/hardware/firmware/esp32/src/controllers/mp3/mp3_controller.cpp
@@ -118,11 +118,7 @@ void Mp3Controller::printBackendStatus(Print& out, const char* source) const {
   const char* safeSource = (source != nullptr && source[0] != '\0') ? source : "status";
   const Mp3BackendRuntimeStats stats = player_.backendStats();
   out.printf(
-<<<<<<< HEAD
       "[MP3_BACKEND_STATUS] %s mode=%s active=%s err=%s last_fallback_reason=%s attempts=%lu success=%lu fail=%lu retries=%lu fallback=%lu legacy=%lu tools=%lu tools_attempt=%lu tools_ok=%lu tools_fail=%lu tools_retry=%lu legacy_attempt=%lu legacy_ok=%lu legacy_fail=%lu legacy_retry=%lu\n",
-=======
-      "[MP3_BACKEND_STATUS] %s mode=%s active=%s err=%s attempts=%lu success=%lu fail=%lu retries=%lu fallback=%lu legacy=%lu tools=%lu last_fail=%s last_fallback=%s\n",
->>>>>>> feature/MPRC-RC1-mp3-audio
       safeSource,
       player_.backendModeLabel(),
       player_.activeBackendLabel(),
@@ -135,7 +131,6 @@ void Mp3Controller::printBackendStatus(Print& out, const char* source) const {
       static_cast<unsigned long>(stats.fallbackCount),
       static_cast<unsigned long>(stats.legacyStarts),
       static_cast<unsigned long>(stats.audioToolsStarts),
-<<<<<<< HEAD
       static_cast<unsigned long>(stats.audioToolsAttempts),
       static_cast<unsigned long>(stats.audioToolsSuccess),
       static_cast<unsigned long>(stats.audioToolsFailures),
@@ -144,10 +139,6 @@ void Mp3Controller::printBackendStatus(Print& out, const char* source) const {
       static_cast<unsigned long>(stats.legacySuccess),
       static_cast<unsigned long>(stats.legacyFailures),
       static_cast<unsigned long>(stats.legacyRetries));
-=======
-      stats.lastFailureReason,
-      stats.lastFallbackPath);
->>>>>>> feature/MPRC-RC1-mp3-audio
 }
 
 void Mp3Controller::printBrowseList(Print& out,
@@ -213,25 +204,17 @@ void Mp3Controller::printQueuePreview(Print& out, uint8_t count, const char* sou
 
 void Mp3Controller::printCapabilities(Print& out, const char* source) const {
   const char* safeSource = (source != nullptr && source[0] != '\0') ? source : "status";
-<<<<<<< HEAD
   char toolsCaps[72] = {};
   char legacyCaps[72] = {};
   formatCaps(player_.audioToolsCapabilities(), toolsCaps, sizeof(toolsCaps));
   formatCaps(player_.legacyCapabilities(), legacyCaps, sizeof(legacyCaps));
   out.printf(
       "[MP3_CAPS] %s codecs=MP3,WAV,AAC,FLAC,OPUS tools=%s legacy=%s mode=%s active=%s\n",
-=======
-  const Mp3BackendRuntimeStats stats = player_.backendStats();
-  out.printf(
-      "[MP3_CAPS] %s codecs=MP3,WAV,AAC,FLAC,OPUS tools=WAV legacy=MP3,WAV,AAC,FLAC,OPUS mode=%s active=%s fallback=%lu last_fail=%s\n",
->>>>>>> feature/MPRC-RC1-mp3-audio
       safeSource,
       toolsCaps,
       legacyCaps,
       player_.backendModeLabel(),
-      player_.activeBackendLabel(),
-      static_cast<unsigned long>(stats.fallbackCount),
-      stats.lastFailureReason);
+      player_.activeBackendLabel());
 }
 
 Mp3Player& Mp3Controller::player() {


### PR DESCRIPTION
Restore mp3 firmware sources to last known clean state to remove accidental merge markers.